### PR TITLE
TrajOpt timeout check constraint convergence and if satisfied report converged

### DIFF
--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -592,6 +592,14 @@ OptStatus BasicTrustRegionSQP::optimize()
       {
         LOG_INFO("Elapsed time %f has exceeded max time %f", elapsed_time, param_.max_time);
         retval = OPT_TIME_LIMIT;
+
+        if (results_.cnt_viols.empty() || vecMax(results_.cnt_viols) < param_.cnt_tolerance)
+        {
+          retval = OPT_CONVERGED;
+          if (!results_.cnt_viols.empty())
+            LOG_INFO("woo-hoo! constraints are satisfied (to tolerance %.2e)", param_.cnt_tolerance);
+        }
+
         goto cleanup;
       }
       callCallbacks();


### PR DESCRIPTION
Currently a timeout is considered a failure, but if constraints are satisfied it should report convergence.