### PR TITLE
Expose convex solver settings and set ospq adaptive_rho to default value

### DIFF
--- a/.github/workflows/windows_noetic_build.yml
+++ b/.github/workflows/windows_noetic_build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   windows_ci:
     name: Noetic
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       ROS_DISTRO: noetic
     steps:

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -114,6 +114,9 @@ struct BasicInfo
   /** @brief The convex solver to use */
   sco::ModelType convex_solver;
 
+  /** @brief The convex solver configuration settings */
+  sco::ModelConfig::Ptr convex_solver_config;
+
   /** @brief If true, the last column in the optimization matrix will be 1/dt */
   bool use_time = false;
 

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -539,8 +539,10 @@ TrajOptProb::Ptr ConstructProblem(const Json::Value& root, const tesseract_envir
   return ConstructProblem(pci);
 }
 
+TrajOptProb::TrajOptProb() = default;
+
 TrajOptProb::TrajOptProb(int n_steps, const ProblemConstructionInfo& pci)
-  : OptProb(pci.basic_info.convex_solver), m_kin(pci.kin), m_env(pci.env)
+  : OptProb(pci.basic_info.convex_solver, pci.basic_info.convex_solver_config), m_kin(pci.kin), m_env(pci.env)
 {
   const Eigen::MatrixX2d& limits = m_kin->getLimits().joint_limits;
   auto n_dof = static_cast<int>(m_kin->numJoints());
@@ -569,8 +571,6 @@ TrajOptProb::TrajOptProb(int n_steps, const ProblemConstructionInfo& pci)
   sco::VarVector trajvarvec = createVariables(names, vlower, vupper);
   m_traj_vars = VarArray(n_steps, n_dof + (pci.basic_info.use_time ? 1 : 0), trajvarvec.data());
 }
-
-TrajOptProb::TrajOptProb() = default;
 
 void UserDefinedTermInfo::fromJson(ProblemConstructionInfo& /*pci*/, const Json::Value& /*v*/)
 {

--- a/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
@@ -37,7 +37,7 @@ OSQPEigenSolver::OSQPEigenSolver()
     solver_.settings()->setVerbosity(false);
   solver_.settings()->setWarmStart(true);
   solver_.settings()->setPolish(true);
-  solver_.settings()->setAdaptiveRho(false);
+  solver_.settings()->setAdaptiveRho(true);
   solver_.settings()->setMaxIteration(8192);
   solver_.settings()->setAbsoluteTolerance(1e-4);
   solver_.settings()->setRelativeTolerance(1e-6);

--- a/trajopt_optimizers/trajopt_sqp/test/cart_position_optimization_trajopt_sco_unit.cpp
+++ b/trajopt_optimizers/trajopt_sqp/test/cart_position_optimization_trajopt_sco_unit.cpp
@@ -155,8 +155,11 @@ TEST(CartPositionOptimizationTrajoptSCO, cart_position_optimization_trajopt_sco)
 
   tesseract_common::TrajArray traj = getTraj(opt.x(), prob->GetVars());
 
-  for (Eigen::Index i = 0; i < traj.cols(); i++)
-    EXPECT_NEAR(traj(0, i), joint_target[i], 1.1e-3);
+  auto optimized_pose = manip->calcFwdKin(traj.row(0)).at("r_gripper_tool_frame");
+  EXPECT_TRUE(target_pose.translation().isApprox(optimized_pose.translation(), 1e-4));
+  Eigen::Quaterniond target_q(target_pose.rotation());
+  Eigen::Quaterniond optimized_q(optimized_pose.rotation());
+  EXPECT_TRUE(target_q.isApprox(optimized_q, 1e-5));
 
   if (DEBUG)
   {

--- a/trajopt_optimizers/trajopt_sqp/test/cart_position_optimization_unit.cpp
+++ b/trajopt_optimizers/trajopt_sqp/test/cart_position_optimization_unit.cpp
@@ -152,8 +152,11 @@ void runCartPositionOptimization(const trajopt_sqp::QPProblem::Ptr& qp_problem,
   solver.solve(qp_problem);
   Eigen::VectorXd x = qp_problem->getVariableValues();
 
-  for (Eigen::Index i = 0; i < joint_target.size(); i++)
-    EXPECT_NEAR(x[i], joint_target[i], 1.1e-3);
+  auto optimized_pose = manip->calcFwdKin(x).at("r_gripper_tool_frame");
+  EXPECT_TRUE(target_pose.translation().isApprox(optimized_pose.translation(), 1e-4));
+  Eigen::Quaterniond target_q(target_pose.rotation());
+  Eigen::Quaterniond optimized_q(optimized_pose.rotation());
+  EXPECT_TRUE(target_q.isApprox(optimized_q, 1e-5));
 
   if (DEBUG)
   {

--- a/trajopt_sco/include/trajopt_sco/modeling.hpp
+++ b/trajopt_sco/include/trajopt_sco/modeling.hpp
@@ -197,7 +197,8 @@ class OptProb
 public:
   using Ptr = std::shared_ptr<OptProb>;
 
-  OptProb(ModelType convex_solver = ModelType::AUTO_SOLVER);
+  OptProb(ModelType convex_solver = ModelType::AUTO_SOLVER,
+          const ModelConfig::ConstPtr& convex_solver_config = nullptr);
   virtual ~OptProb() = default;
   OptProb(const OptProb&) = delete;
   OptProb& operator=(const OptProb&) = delete;

--- a/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
@@ -9,6 +9,17 @@ TRAJOPT_IGNORE_WARNINGS_POP
 
 namespace sco
 {
+/** @brief The OSQP configuration settings */
+struct OSQPModelConfig : public ModelConfig
+{
+  using Ptr = std::shared_ptr<OSQPModelConfig>;
+  using ConstPtr = std::shared_ptr<const OSQPModelConfig>;
+
+  OSQPModelConfig();
+
+  OSQPSettings settings;
+};
+
 /**
  * OSQPModel uses the BSD solver OSQP to solve a linearly constrained QP.
  * OSQP solves a problem in the form:
@@ -22,9 +33,8 @@ namespace sco
  */
 class OSQPModel : public Model
 {
-  OSQPSettings osqp_settings_; /**< OSQP Settings */
-                               /** OSQPData. Some fields here (`osp_data_.A` and `osp_data_.P`) are
-                                *  automatically allocated by OSQP, but deallocated by us. */
+  /** OSQPData. Some fields here (`osp_data_.A` and `osp_data_.P`) are *  automatically allocated by OSQP, but
+   * deallocated by us. */
   OSQPData osqp_data_;
 
   /** OSQP Workspace. Memory here is managed by OSQP */
@@ -63,8 +73,10 @@ class OSQPModel : public Model
 
   QuadExpr objective_; /**< objective QuadExpr expression */
 
+  OSQPModelConfig config_; /**< The configuration settings */
+
 public:
-  OSQPModel();
+  OSQPModel(const ModelConfig::ConstPtr& config = nullptr);
   ~OSQPModel() override;
   OSQPModel(const OSQPModel& model) = delete;
   OSQPModel& operator=(const OSQPModel& model) = delete;

--- a/trajopt_sco/include/trajopt_sco/solver_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/solver_interface.hpp
@@ -86,6 +86,13 @@ public:
   virtual VarVector getVars() const = 0;
 };
 
+struct ModelConfig
+{
+  using Ptr = std::shared_ptr<ModelConfig>;
+  using ConstPtr = std::shared_ptr<const ModelConfig>;
+  virtual ~ModelConfig() = default;
+};
+
 struct VarRep
 {
   using Ptr = std::shared_ptr<VarRep>;
@@ -232,7 +239,8 @@ std::vector<ModelType> availableSolvers();
 
 std::ostream& operator<<(std::ostream& os, const ModelType& cs);
 
-Model::Ptr createModel(ModelType model_type = ModelType::AUTO_SOLVER);
+Model::Ptr createModel(ModelType model_type = ModelType::AUTO_SOLVER,
+                       const ModelConfig::ConstPtr& model_config = nullptr);
 
 void vars2inds(const VarVector& vars, SizeTVec& inds);
 

--- a/trajopt_sco/src/modeling.cpp
+++ b/trajopt_sco/src/modeling.cpp
@@ -160,7 +160,10 @@ DblVec Constraint::violations(const DblVec& x)
 }
 
 double Constraint::violation(const DblVec& x) { return vecSum(violations(x)); }
-OptProb::OptProb(ModelType convex_solver) : model_(createModel(convex_solver)) {}
+OptProb::OptProb(ModelType convex_solver, const ModelConfig::ConstPtr& convex_solver_config)
+  : model_(createModel(convex_solver, convex_solver_config))
+{
+}
 VarVector OptProb::createVariables(const std::vector<std::string>& names)
 {
   return createVariables(names, DblVec(names.size(), -INFINITY), DblVec(names.size(), INFINITY));

--- a/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt_sco/src/solver_interface.cpp
@@ -276,13 +276,13 @@ std::vector<ModelType> availableSolvers()
   return available_solvers;
 }
 
-Model::Ptr createModel(ModelType model_type)
+Model::Ptr createModel(ModelType model_type, const ModelConfig::ConstPtr& model_config)
 {
 #ifdef HAVE_GUROBI
   extern Model::Ptr createGurobiModel();
 #endif
 #ifdef HAVE_OSQP
-  extern Model::Ptr createOSQPModel();
+  extern Model::Ptr createOSQPModel(const ModelConfig::ConstPtr& config);
 #endif
 #ifdef HAVE_BPMPD
   extern Model::Ptr createBPMPDModel();
@@ -337,7 +337,7 @@ Model::Ptr createModel(ModelType model_type)
 #endif
 #ifdef HAVE_OSQP
   if (solver == ModelType::OSQP)
-    return createOSQPModel();
+    return createOSQPModel(model_config);
 #endif
 #ifdef HAVE_BPMPD
   if (solver == ModelType::BPMPD)


### PR DESCRIPTION
The adaptive_rho was change because a unit test was failing [here](https://github.com/tesseract-robotics/trajopt/pull/172) but now passes using the default setting indicating that either there was an issue in OSQP or TrajOpt that has been fixed. Have adaptive_rho enable has a signification impact on planning time so it is reverted to default value now that the setting is exposed.