### PR TITLE
Build Failure with GUROBI support

### DIFF
--- a/trajopt_sco/cmake/FindGUROBI.cmake
+++ b/trajopt_sco/cmake/FindGUROBI.cmake
@@ -18,7 +18,10 @@ find_path(
 
 find_library(
   GUROBI_LIBRARY
-  NAMES gurobi gurobi81 gurobi90
+  NAMES gurobi
+        gurobi81
+        gurobi90
+        gurobi95
   HINTS ${GUROBI_DIR} $ENV{GUROBI_HOME}
   PATH_SUFFIXES lib)
 

--- a/trajopt_sco/src/gurobi_interface.cpp
+++ b/trajopt_sco/src/gurobi_interface.cpp
@@ -157,12 +157,12 @@ Cnt GurobiModel::addIneqCnt(const QuadExpr& qexpr, const std::string& name)
 void resetIndices(VarVector& vars)
 {
   for (size_t i = 0; i < vars.size(); ++i)
-    vars[i].var_rep[i].index = i;
+    vars[i].var_rep->index = i;
 }
 void resetIndices(CntVector& cnts)
 {
   for (size_t i = 0; i < cnts.size(); ++i)
-    cnts[i].cnt_rep[i].index = i;
+    cnts[i].cnt_rep->index = i;
 }
 
 void GurobiModel::removeVars(const VarVector& vars)


### PR DESCRIPTION
As discussed in Issue https://github.com/tesseract-robotics/trajopt/issues/295, this PR fixes a build issue when compiling the `trajopt_sco` package with gurobi support. Additionally, it updates the cmake routines to account for newer versions of the gurobi solver.