### PR TITLE
Filter contact pairs with zero coeffs

### DIFF
--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -935,7 +935,15 @@ void SingleTimestepCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eig
 
   contact_manager_->contactTest(dist_results, contact_test_type_);
 
-  auto filter = [this](tesseract_collision::ContactResultMap::PairType& pair) {
+  const auto& zero_coeff_pairs = getSafetyMarginData()->getPairsWithZeroCoeff();
+  auto filter = [this, &zero_coeff_pairs](tesseract_collision::ContactResultMap::PairType& pair) {
+    // Remove pairs with zero coeffs
+    if (std::find(zero_coeff_pairs.begin(), zero_coeff_pairs.end(), pair.first) != zero_coeff_pairs.end())
+    {
+      pair.second.clear();
+      return;
+    }
+
     // Contains the contact distance threshold and coefficient for the given link pair
     const std::array<double, 2>& data =
         getSafetyMarginData()->getPairSafetyMarginData(pair.first.first, pair.first.second);
@@ -1126,10 +1134,18 @@ void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Ve
     subtraj.col(i) = Eigen::VectorXd::LinSpaced(cnt, dof_vals0(i), dof_vals1(i));
 
   // Define Filter
-  auto filter = [this](tesseract_collision::ContactResultMap::PairType& pair) {
+  const auto& zero_coeff_pairs = getSafetyMarginData()->getPairsWithZeroCoeff();
+  auto filter = [this, &zero_coeff_pairs](tesseract_collision::ContactResultMap::PairType& pair) {
+    // Remove pairs with zero coeffs
+    if (std::find(zero_coeff_pairs.begin(), zero_coeff_pairs.end(), pair.first) != zero_coeff_pairs.end())
+    {
+      pair.second.clear();
+      return;
+    }
+
+    // Don't include contacts at the fixed state
     const std::array<double, 2>& data =
         getSafetyMarginData()->getPairSafetyMarginData(pair.first.first, pair.first.second);
-    // Don't include contacts at the fixed state
     removeInvalidContactResults(pair.second, data);
   };
 
@@ -1350,10 +1366,18 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
   }
 
   // Define Filter
-  auto filter = [this](tesseract_collision::ContactResultMap::PairType& pair) {
+  const auto& zero_coeff_pairs = getSafetyMarginData()->getPairsWithZeroCoeff();
+  auto filter = [this, &zero_coeff_pairs](tesseract_collision::ContactResultMap::PairType& pair) {
+    // Remove pairs with zero coeffs
+    if (std::find(zero_coeff_pairs.begin(), zero_coeff_pairs.end(), pair.first) != zero_coeff_pairs.end())
+    {
+      pair.second.clear();
+      return;
+    }
+
+    // Don't include contacts at the fixed state
     const std::array<double, 2>& data =
         getSafetyMarginData()->getPairSafetyMarginData(pair.first.first, pair.first.second);
-    // Don't include contacts at the fixed state
     removeInvalidContactResults(pair.second, data);
   };
 

--- a/trajopt_ifopt/include/trajopt_ifopt/constraints/collision/collision_types.h
+++ b/trajopt_ifopt/include/trajopt_ifopt/constraints/collision/collision_types.h
@@ -48,7 +48,7 @@ struct CollisionCoeffData
   using Ptr = std::shared_ptr<CollisionCoeffData>;
   using ConstPtr = std::shared_ptr<const CollisionCoeffData>;
 
-  CollisionCoeffData(const double& default_collision_coeff = 1);
+  CollisionCoeffData(double default_collision_coeff = 1);
 
   /**
    * @brief Set the coefficient for a given contact pair
@@ -60,7 +60,7 @@ struct CollisionCoeffData
    * @param obj2 The Second object name. Order doesn't matter
    * @param Coeff Coefficient
    */
-  void setPairCollisionCoeff(const std::string& obj1, const std::string& obj2, const double& collision_coeff);
+  void setPairCollisionCoeff(const std::string& obj1, const std::string& obj2, double collision_coeff);
 
   /**
    * @brief Get the pairs collision coefficient
@@ -71,7 +71,13 @@ struct CollisionCoeffData
    * @param obj2 The second object name
    * @return Coefficient
    */
-  const double& getPairCollisionCoeff(const std::string& obj1, const std::string& obj2) const;
+  double getPairCollisionCoeff(const std::string& obj1, const std::string& obj2) const;
+
+  /**
+   * @brief Get the pairs with zero coeff
+   * @return A vector of pairs with zero coeff
+   */
+  const std::set<tesseract_common::LinkNamesPair>& getPairsWithZeroCoeff() const;
 
 private:
   /// Stores the collision coefficient used if no pair-specific one is set
@@ -79,6 +85,9 @@ private:
 
   /// A map of link pair names to contact distance
   std::unordered_map<tesseract_common::LinkNamesPair, double, tesseract_common::PairHash> lookup_table_;
+
+  /// Pairs containing zero coeff
+  std::set<tesseract_common::LinkNamesPair> zero_coeff_;
 };
 
 /**

--- a/trajopt_ifopt/src/constraints/collision/collision_types.cpp
+++ b/trajopt_ifopt/src/constraints/collision/collision_types.cpp
@@ -26,29 +26,36 @@
 
 namespace trajopt_ifopt
 {
-CollisionCoeffData::CollisionCoeffData(const double& default_collision_coeff)
+CollisionCoeffData::CollisionCoeffData(double default_collision_coeff)
   : default_collision_coeff_(default_collision_coeff)
 {
 }
 
-void CollisionCoeffData::setPairCollisionCoeff(const std::string& obj1,
-                                               const std::string& obj2,
-                                               const double& collision_coeff)
+void CollisionCoeffData::setPairCollisionCoeff(const std::string& obj1, const std::string& obj2, double collision_coeff)
 {
   auto key = tesseract_common::makeOrderedLinkPair(obj1, obj2);
   lookup_table_[key] = collision_coeff;
+
+  if (tesseract_common::almostEqualRelativeAndAbs(collision_coeff, 0.0))
+    zero_coeff_.insert(key);
+  else
+    zero_coeff_.erase(key);
 }
 
-const double& CollisionCoeffData::getPairCollisionCoeff(const std::string& obj1, const std::string& obj2) const
+double CollisionCoeffData::getPairCollisionCoeff(const std::string& obj1, const std::string& obj2) const
 {
   auto key = tesseract_common::makeOrderedLinkPair(obj1, obj2);
   const auto it = lookup_table_.find(key);
 
   if (it != lookup_table_.end())
-  {
     return it->second;
-  }
+
   return default_collision_coeff_;
+}
+
+const std::set<tesseract_common::LinkNamesPair>& CollisionCoeffData::getPairsWithZeroCoeff() const
+{
+  return zero_coeff_;
 }
 
 TrajOptCollisionConfig::TrajOptCollisionConfig(double margin, double coeff)

--- a/trajopt_ifopt/src/constraints/collision/continuous_collision_evaluators.cpp
+++ b/trajopt_ifopt/src/constraints/collision/continuous_collision_evaluators.cpp
@@ -181,7 +181,16 @@ void LVSContinuousCollisionEvaluator::CalcCollisionsHelper(const Eigen::Ref<cons
 
   // Create filter
   // Don't include contacts at the fixed state
-  auto filter = [this](tesseract_collision::ContactResultMap::PairType& pair) {
+  // Don't include contacts with zero coeffs
+  const auto& zero_coeff_pairs = collision_config_->collision_coeff_data.getPairsWithZeroCoeff();
+  auto filter = [this, &zero_coeff_pairs](tesseract_collision::ContactResultMap::PairType& pair) {
+    // Remove pairs with zero coeffs
+    if (std::find(zero_coeff_pairs.begin(), zero_coeff_pairs.end(), pair.first) != zero_coeff_pairs.end())
+    {
+      pair.second.clear();
+      return;
+    }
+
     // Contains the contact distance threshold and coefficient for the given link pair
     double dist = collision_config_->contact_manager_config.margin_data.getPairCollisionMargin(pair.first.first,
                                                                                                pair.first.second);
@@ -400,7 +409,17 @@ void LVSDiscreteCollisionEvaluator::CalcCollisionsHelper(const Eigen::Ref<const 
   }
 
   // Create filter
-  auto filter = [this](tesseract_collision::ContactResultMap::PairType& pair) {
+  // Don't include contacts at the fixed state
+  // Don't include contacts with zero coeffs
+  const auto& zero_coeff_pairs = collision_config_->collision_coeff_data.getPairsWithZeroCoeff();
+  auto filter = [this, &zero_coeff_pairs](tesseract_collision::ContactResultMap::PairType& pair) {
+    // Remove pairs with zero coeffs
+    if (std::find(zero_coeff_pairs.begin(), zero_coeff_pairs.end(), pair.first) != zero_coeff_pairs.end())
+    {
+      pair.second.clear();
+      return;
+    }
+
     // Contains the contact distance threshold and coefficient for the given link pair
     double dist = collision_config_->contact_manager_config.margin_data.getPairCollisionMargin(pair.first.first,
                                                                                                pair.first.second);

--- a/trajopt_ifopt/src/constraints/collision/discrete_collision_evaluators.cpp
+++ b/trajopt_ifopt/src/constraints/collision/discrete_collision_evaluators.cpp
@@ -155,7 +155,16 @@ void SingleTimestepCollisionEvaluator::CalcCollisionsHelper(const Eigen::Ref<con
   contact_manager_->contactTest(dist_results, collision_config_->contact_request);
 
   // Don't include contacts at the fixed state
-  auto filter = [this](tesseract_collision::ContactResultMap::PairType& pair) {
+  // Don't include contacts with zero coeffs
+  const auto& zero_coeff_pairs = collision_config_->collision_coeff_data.getPairsWithZeroCoeff();
+  auto filter = [this, &zero_coeff_pairs](tesseract_collision::ContactResultMap::PairType& pair) {
+    // Remove pairs with zero coeffs
+    if (std::find(zero_coeff_pairs.begin(), zero_coeff_pairs.end(), pair.first) != zero_coeff_pairs.end())
+    {
+      pair.second.clear();
+      return;
+    }
+
     // Contains the contact distance threshold and coefficient for the given link pair
     double dist = collision_config_->contact_manager_config.margin_data.getPairCollisionMargin(pair.first.first,
                                                                                                pair.first.second);

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -695,7 +695,8 @@ OptStatus BasicTrustRegionSQP::optimize()
             qp_solver_failures++;
             continue;
           }
-          else if (qp_solver_failures == (param_.max_qp_solver_failures - 1))
+
+          if (qp_solver_failures == (param_.max_qp_solver_failures - 1))
           {
             // convex solver failed and this is the last attempt so setting the trust region to the minimum.
             setTrustRegionSize(param_.min_trust_box_size);
@@ -703,6 +704,7 @@ OptStatus BasicTrustRegionSQP::optimize()
             qp_solver_failures++;
             continue;
           }
+
           LOG_ERROR("The convex solver failed you one too many times.");
           retval = OPT_FAILED;
           goto cleanup;

--- a/trajopt_utils/include/trajopt_utils/utils.hpp
+++ b/trajopt_utils/include/trajopt_utils/utils.hpp
@@ -58,6 +58,12 @@ struct SafetyMarginData
    */
   double getMaxSafetyMargin() const;
 
+  /**
+   * @brief Get the pairs with zero coeff
+   * @return A vector of pairs with zero coeff
+   */
+  const std::set<tesseract_common::LinkNamesPair>& getPairsWithZeroCoeff() const;
+
 private:
   /// The coeff used during optimization
   /// safety margin: contacts with distance < dist_pen are penalized
@@ -71,6 +77,9 @@ private:
   /// A map of link pair to contact distance setting [dist_pen, coeff]
   std::unordered_map<tesseract_common::LinkNamesPair, std::array<double, 2>, tesseract_common::PairHash>
       pair_lookup_table_;
+
+  /// Pairs containing zero coeff
+  std::set<tesseract_common::LinkNamesPair> zero_coeff_;
 };
 
 /**

--- a/trajopt_utils/src/utils.cpp
+++ b/trajopt_utils/src/utils.cpp
@@ -1,4 +1,5 @@
 #include <trajopt_utils/utils.hpp>
+#include <tesseract_common/utils.h>
 
 namespace util
 {
@@ -19,6 +20,11 @@ void SafetyMarginData::setPairSafetyMarginData(const std::string& obj1,
 
   if (safety_margin > max_safety_margin_)
     max_safety_margin_ = safety_margin;
+
+  if (tesseract_common::almostEqualRelativeAndAbs(safety_margin_coeff, 0.0))
+    zero_coeff_.insert(key);
+  else
+    zero_coeff_.erase(key);
 }
 
 const std::array<double, 2>& SafetyMarginData::getPairSafetyMarginData(const std::string& obj1,
@@ -36,6 +42,8 @@ const std::array<double, 2>& SafetyMarginData::getPairSafetyMarginData(const std
 }
 
 double SafetyMarginData::getMaxSafetyMargin() const { return max_safety_margin_; }
+
+const std::set<tesseract_common::LinkNamesPair>& SafetyMarginData::getPairsWithZeroCoeff() const { return zero_coeff_; }
 
 std::vector<SafetyMarginData::Ptr> createSafetyMarginDataVector(int num_elements,
                                                                 double default_safety_margin,


### PR DESCRIPTION
This is an optimization to filter out unused data early to avoid unnecessary calculations when coeff is set to zero for collision pair. 