### PR TITLE
Add multi-threaded support to TrajOpt

### DIFF
--- a/.github/workflows/focal_build.yml
+++ b/.github/workflows/focal_build.yml
@@ -26,7 +26,7 @@ jobs:
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTRAJOPT_ENABLE_TESTING=ON -DTRAJOPT_ENABLE_CLANG_TIDY=ON"
       AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose trajopt trajopt_ifopt trajopt_sco trajopt_sqp --make-args test'
-      ADDITIONAL_DEBS: clang-tidy-12
+      ADDITIONAL_DEBS: clang-tidy
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/unstable_build.yml
+++ b/.github/workflows/unstable_build.yml
@@ -26,7 +26,7 @@ jobs:
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTRAJOPT_ENABLE_TESTING=ON -DTRAJOPT_ENABLE_CLANG_TIDY=ON"
       AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose trajopt trajopt_ifopt trajopt_sco trajopt_sqp --make-args test'
-      ADDITIONAL_DEBS: clang-tidy-12
+      ADDITIONAL_DEBS: clang-tidy
     steps:
       - uses: actions/checkout@v1
 

--- a/trajopt/test/benchmarks/solve_benchmarks.cpp
+++ b/trajopt/test/benchmarks/solve_benchmarks.cpp
@@ -58,6 +58,22 @@ static void BM_TRAJOPT_PLANNING_SOLVE(benchmark::State& state, Environment::Ptr 
   }
 }
 
+/** @brief Benchmark trajopt planning solve */
+static void BM_TRAJOPT_MULTI_THREADED_PLANNING_SOLVE(benchmark::State& state, Environment::Ptr env, Json::Value root)
+{
+  for (auto _ : state)
+  {
+    ProblemConstructionInfo pci(env);
+    pci.fromJson(root);
+    pci.basic_info.convex_solver = sco::ModelType::OSQP;
+    TrajOptProb::Ptr prob = ConstructProblem(pci);
+    sco::BasicTrustRegionSQPMultiThreaded opt(prob);
+    opt.getParameters().num_threads = 5;
+    opt.initialize(trajToDblVec(prob->GetInitTraj()));
+    opt.optimize();
+  }
+}
+
 int main(int argc, char** argv)
 {
   gLogLevel = util::LevelError;

--- a/trajopt/test/benchmarks/solve_benchmarks.cpp
+++ b/trajopt/test/benchmarks/solve_benchmarks.cpp
@@ -58,6 +58,21 @@ static void BM_TRAJOPT_PLANNING_SOLVE(benchmark::State& state, Environment::Ptr 
   }
 }
 
+/** @brief Benchmark trajopt simple collision solve */
+static void BM_TRAJOPT_MULTI_THREADED_SIMPLE_COLLISION_SOLVE(benchmark::State& state,
+                                                             Environment::Ptr env,
+                                                             Json::Value root)
+{
+  for (auto _ : state)
+  {
+    TrajOptProb::Ptr prob = ConstructProblem(root, env);
+    sco::BasicTrustRegionSQPMultiThreaded opt(prob);
+    opt.getParameters().num_threads = 5;
+    opt.initialize(trajToDblVec(prob->GetInitTraj()));
+    opt.optimize();
+  }
+}
+
 /** @brief Benchmark trajopt planning solve */
 static void BM_TRAJOPT_MULTI_THREADED_PLANNING_SOLVE(benchmark::State& state, Environment::Ptr env, Json::Value root)
 {

--- a/trajopt/test/cast_cost_octomap_unit.cpp
+++ b/trajopt/test/cast_cost_octomap_unit.cpp
@@ -94,7 +94,7 @@ public:
   }
 };
 
-TEST_F(CastOctomapTest, boxes)  // NOLINT
+void runTest(const Environment::Ptr& env, const Visualization::Ptr& plotter, bool use_multi_threaded)
 {
   CONSOLE_BRIDGE_logDebug("CastOctomapTest, boxes");
 
@@ -103,11 +103,11 @@ TEST_F(CastOctomapTest, boxes)  // NOLINT
   std::unordered_map<std::string, double> ipos;
   ipos["boxbot_x_joint"] = -1.9;
   ipos["boxbot_y_joint"] = 0;
-  env_->setState(ipos);
+  env->setState(ipos);
 
   //  plotter_->plotScene();
 
-  TrajOptProb::Ptr prob = ConstructProblem(root, env_);
+  TrajOptProb::Ptr prob = ConstructProblem(root, env);
   ASSERT_TRUE(!!prob);
 
   std::vector<ContactResultMap> collisions;
@@ -125,21 +125,41 @@ TEST_F(CastOctomapTest, boxes)  // NOLINT
   EXPECT_TRUE(found);
   CONSOLE_BRIDGE_logDebug((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  sco::BasicTrustRegionSQP opt(prob);
-  if (plotting)
-    opt.addCallback(PlotCallback(plotter_));
-  opt.initialize(trajToDblVec(prob->GetInitTraj()));
-  opt.optimize();
+  sco::BasicTrustRegionSQP::Ptr opt;
+  if (use_multi_threaded)
+  {
+    opt = std::make_shared<sco::BasicTrustRegionSQPMultiThreaded>(prob);
+    opt->getParameters().num_threads = 5;
+  }
+  else
+  {
+    opt = std::make_shared<sco::BasicTrustRegionSQP>(prob);
+  }
 
   if (plotting)
-    plotter_->clear();
+    opt->addCallback(PlotCallback(plotter));
+  opt->initialize(trajToDblVec(prob->GetInitTraj()));
+  opt->optimize();
+
+  if (plotting)
+    plotter->clear();
 
   collisions.clear();
   found = checkTrajectory(
-      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()), config);
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt->x(), prob->GetVars()), config);
 
   EXPECT_FALSE(found);
   CONSOLE_BRIDGE_logDebug((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
+}
+
+TEST_F(CastOctomapTest, boxes)  // NOLINT
+{
+  runTest(env_, plotter_, false);
+}
+
+TEST_F(CastOctomapTest, boxes_milti_threaded)  // NOLINT
+{
+  runTest(env_, plotter_, false);
 }
 
 int main(int argc, char** argv)

--- a/trajopt/test/cast_cost_unit.cpp
+++ b/trajopt/test/cast_cost_unit.cpp
@@ -52,7 +52,7 @@ public:
   }
 };
 
-TEST_F(CastTest, boxes)  // NOLINT
+void runTest(const Environment::Ptr& env, const Visualization::Ptr& plotter, bool use_multi_threaded)
 {
   CONSOLE_BRIDGE_logDebug("CastTest, boxes");
 
@@ -61,11 +61,11 @@ TEST_F(CastTest, boxes)  // NOLINT
   std::unordered_map<std::string, double> ipos;
   ipos["boxbot_x_joint"] = -1.9;
   ipos["boxbot_y_joint"] = 0;
-  env_->setState(ipos);
+  env->setState(ipos);
 
   //  plotter_->plotScene();
 
-  TrajOptProb::Ptr prob = ConstructProblem(root, env_);
+  TrajOptProb::Ptr prob = ConstructProblem(root, env);
   ASSERT_TRUE(!!prob);
 
   std::vector<ContactResultMap> collisions;
@@ -84,23 +84,43 @@ TEST_F(CastTest, boxes)  // NOLINT
   EXPECT_TRUE(found);
   CONSOLE_BRIDGE_logDebug((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  sco::BasicTrustRegionSQP opt(prob);
-  if (plotting)
-    opt.addCallback(PlotCallback(plotter_));
-  opt.initialize(trajToDblVec(prob->GetInitTraj()));
-  opt.optimize();
+  sco::BasicTrustRegionSQP::Ptr opt;
+  if (use_multi_threaded)
+  {
+    opt = std::make_shared<sco::BasicTrustRegionSQPMultiThreaded>(prob);
+    opt->getParameters().num_threads = 5;
+  }
+  else
+  {
+    opt = std::make_shared<sco::BasicTrustRegionSQP>(prob);
+  }
 
   if (plotting)
-    plotter_->clear();
+    opt->addCallback(PlotCallback(plotter));
+  opt->initialize(trajToDblVec(prob->GetInitTraj()));
+  opt->optimize();
+
+  if (plotting)
+    plotter->clear();
 
   collisions.clear();
-  std::cout << getTraj(opt.x(), prob->GetVars()) << std::endl;
+  std::cout << getTraj(opt->x(), prob->GetVars()) << std::endl;
 
   found = checkTrajectory(
-      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()), config);
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt->x(), prob->GetVars()), config);
 
   EXPECT_FALSE(found);
   CONSOLE_BRIDGE_logDebug((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
+}
+
+TEST_F(CastTest, boxes)  // NOLINT
+{
+  runTest(env_, plotter_, false);
+}
+
+TEST_F(CastTest, boxes_multi_threaded)  // NOLINT
+{
+  runTest(env_, plotter_, true);
 }
 
 int main(int argc, char** argv)

--- a/trajopt/test/simple_collision_unit.cpp
+++ b/trajopt/test/simple_collision_unit.cpp
@@ -53,7 +53,7 @@ public:
   }
 };
 
-TEST_F(SimpleCollisionTest, spheres)  // NOLINT
+void runTest(const Environment::Ptr& env, const Visualization::Ptr& plotter, bool use_multi_threaded)
 {
   CONSOLE_BRIDGE_logDebug("SimpleCollisionTest, spheres");
 
@@ -62,11 +62,11 @@ TEST_F(SimpleCollisionTest, spheres)  // NOLINT
   std::unordered_map<std::string, double> ipos;
   ipos["spherebot_x_joint"] = -0.75;
   ipos["spherebot_y_joint"] = 0.75;
-  env_->setState(ipos);
+  env->setState(ipos);
 
   //  plotter_->plotScene();
 
-  TrajOptProb::Ptr prob = ConstructProblem(root, env_);
+  TrajOptProb::Ptr prob = ConstructProblem(root, env);
   ASSERT_TRUE(!!prob);
 
   std::vector<ContactResultMap> collisions;
@@ -85,23 +85,43 @@ TEST_F(SimpleCollisionTest, spheres)  // NOLINT
   EXPECT_TRUE(found);
   CONSOLE_BRIDGE_logDebug((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
-  sco::BasicTrustRegionSQP opt(prob);
-  if (plotting)
-    opt.addCallback(PlotCallback(plotter_));
-  opt.initialize(trajToDblVec(prob->GetInitTraj()));
-  opt.optimize();
+  sco::BasicTrustRegionSQP::Ptr opt;
+  if (use_multi_threaded)
+  {
+    opt = std::make_shared<sco::BasicTrustRegionSQPMultiThreaded>(prob);
+    opt->getParameters().num_threads = 5;
+  }
+  else
+  {
+    opt = std::make_shared<sco::BasicTrustRegionSQP>(prob);
+  }
 
   if (plotting)
-    plotter_->clear();
+    opt->addCallback(PlotCallback(plotter));
+  opt->initialize(trajToDblVec(prob->GetInitTraj()));
+  opt->optimize();
+
+  if (plotting)
+    plotter->clear();
 
   collisions.clear();
-  std::cout << getTraj(opt.x(), prob->GetVars()) << std::endl;
+  std::cout << getTraj(opt->x(), prob->GetVars()) << std::endl;
 
   found = checkTrajectory(
-      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()), config);
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt->x(), prob->GetVars()), config);
 
   EXPECT_FALSE(found);
   CONSOLE_BRIDGE_logDebug((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
+}
+
+TEST_F(SimpleCollisionTest, spheres)  // NOLINT
+{
+  runTest(env_, plotter_, false);
+}
+
+TEST_F(SimpleCollisionTest, spheres_multi_threaded)  // NOLINT
+{
+  runTest(env_, plotter_, true);
 }
 
 int main(int argc, char** argv)

--- a/trajopt_sco/CMakeLists.txt
+++ b/trajopt_sco/CMakeLists.txt
@@ -23,6 +23,7 @@ elseif(NOT TARGET jsoncpp_lib)
 endif()
 find_package(ros_industrial_cmake_boilerplate REQUIRED)
 find_package(Boost REQUIRED)
+find_package(OpenMP REQUIRED)
 
 # Load variable for clang tidy args, compiler options and cxx version
 trajopt_variables()
@@ -108,7 +109,8 @@ target_link_libraries(
          Boost::boost
          Eigen3::Eigen
          ${CMAKE_DL_LIBS}
-         jsoncpp_lib)
+         jsoncpp_lib
+         OpenMP::OpenMP_CXX)
 target_compile_options(${PROJECT_NAME} PRIVATE ${TRAJOPT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME} PUBLIC ${TRAJOPT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${TRAJOPT_COMPILE_DEFINITIONS})

--- a/trajopt_sco/cmake/trajopt_sco-config.cmake.in
+++ b/trajopt_sco/cmake/trajopt_sco-config.cmake.in
@@ -19,5 +19,6 @@ if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
 else()
   find_dependency(Boost)
 endif()
+find_dependency(OpenMP)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/trajopt_sco/include/trajopt_sco/bpmpd_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/bpmpd_interface.hpp
@@ -1,4 +1,8 @@
 #pragma once
+#include <trajopt_utils/macros.h>
+TRAJOPT_IGNORE_WARNINGS_PUSH
+#include <mutex>
+TRAJOPT_IGNORE_WARNINGS_POP
 #include <trajopt_sco/solver_interface.hpp>
 
 namespace sco
@@ -19,13 +23,16 @@ public:
   int m_pipeOut{ 0 };
   int m_pid{ 0 };
 
+  std::mutex m_mutex; /**< The mutex */
+
   BPMPDModel();
   ~BPMPDModel() override = default;
-  BPMPDModel(const BPMPDModel&) = default;
-  BPMPDModel& operator=(const BPMPDModel&) = default;
-  BPMPDModel(BPMPDModel&&) = default;
-  BPMPDModel& operator=(BPMPDModel&&) = default;
+  BPMPDModel(const BPMPDModel&) = delete;
+  BPMPDModel& operator=(const BPMPDModel&) = delete;
+  BPMPDModel(BPMPDModel&&) = delete;
+  BPMPDModel& operator=(BPMPDModel&&) = delete;
 
+  // Must be threadsafe
   Var addVar(const std::string& name) override;
   Cnt addEqCnt(const AffExpr&, const std::string& name) override;
   Cnt addIneqCnt(const AffExpr&, const std::string& name) override;
@@ -33,12 +40,13 @@ public:
   void removeVars(const VarVector& vars) override;
   void removeCnts(const CntVector& cnts) override;
 
+  // These do not need to be threadsafe
   void update() override;
-  void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper) override;
-  DblVec getVarValues(const VarVector& vars) const override;
   CvxOptStatus optimize() override;
   void setObjective(const AffExpr&) override;
   void setObjective(const QuadExpr&) override;
+  void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper) override;
+  DblVec getVarValues(const VarVector& vars) const override;
   void writeToFile(const std::string& fname) const override;
   VarVector getVars() const override;
 };

--- a/trajopt_sco/include/trajopt_sco/gurobi_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/gurobi_interface.hpp
@@ -1,4 +1,8 @@
 #pragma once
+#include <trajopt_utils/macros.h>
+TRAJOPT_IGNORE_WARNINGS_PUSH
+#include <mutex>
+TRAJOPT_IGNORE_WARNINGS_POP
 #include <trajopt_sco/solver_interface.hpp>
 
 /**
@@ -22,34 +26,31 @@ public:
   GRBmodel* m_model;
   VarVector m_vars;
   CntVector m_cnts;
+  std::mutex m_mutex;
 
   GurobiModel();
+  ~GurobiModel();
 
+  // Must be threadsafe
   Var addVar(const std::string& name) override;
   Var addVar(const std::string& name, double lower, double upper) override;
-
   Cnt addEqCnt(const AffExpr&, const std::string& name) override;
   Cnt addIneqCnt(const AffExpr&, const std::string& name) override;
   Cnt addIneqCnt(const QuadExpr&, const std::string& name) override;
-
   void removeVars(const VarVector&) override;
   void removeCnts(const CntVector&) override;
 
+  // These do not need to be threadsafe
   void update() override;
-  void setVarBounds(const VarVector&, const DblVec& lower, const DblVec& upper) override;
-  DblVec getVarValues(const VarVector&) const override;
-
   CvxOptStatus optimize() override;
-  /** Don't use this function, because it adds constraints that aren't tracked
-   */
-  CvxOptStatus optimizeFeasRelax();
-
   void setObjective(const AffExpr&) override;
   void setObjective(const QuadExpr&) override;
+  void setVarBounds(const VarVector&, const DblVec& lower, const DblVec& upper) override;
+  DblVec getVarValues(const VarVector&) const override;
   void writeToFile(const std::string& fname) const override;
-
   VarVector getVars() const override;
 
-  ~GurobiModel();
+  /** Don't use this function, because it adds constraints that aren't tracked*/
+  CvxOptStatus optimizeFeasRelax();
 };
 }  // namespace sco

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -154,7 +154,7 @@ public:
   // Utility functions, exposed to allow overriding for multi threaded implementations
   virtual DblVec evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const;
 
-  virtual DblVec evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints, const DblVec& x) const;
+  virtual DblVec evaluateConstraintViols(const std::vector<Constraint::Ptr>& cnts, const DblVec& x) const;
 
   virtual std::vector<ConvexObjective::Ptr> convexifyCosts(const std::vector<Cost::Ptr>& costs,
                                                            const DblVec& x,
@@ -193,7 +193,7 @@ public:
   // Utility functions, exposed to allow overriding for multi threaded implementations
   DblVec evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const override final;
 
-  DblVec evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints, const DblVec& x) const override final;
+  DblVec evaluateConstraintViols(const std::vector<Constraint::Ptr>& cnts, const DblVec& x) const override final;
 
   std::vector<ConvexObjective::Ptr> convexifyCosts(const std::vector<Cost::Ptr>& costs,
                                                    const DblVec& x,

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -265,12 +265,6 @@ public:
   DblVec evaluateModelCosts(const std::vector<ConvexObjective::Ptr>& costs, const DblVec& x) const override final;
 
   DblVec evaluateModelCntViols(const std::vector<ConvexConstraints::Ptr>& cnts, const DblVec& x) const override final;
-
-  std::vector<std::string> getCostNames(const std::vector<Cost::Ptr>& costs) const override final;
-
-  std::vector<std::string> getCntNames(const std::vector<Constraint::Ptr>& cnts) const override final;
-
-  std::vector<std::string> getVarNames(const VarVector& vars) const override final;
 };
 
 /**

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -125,65 +125,6 @@ struct BasicTrustRegionSQPParameters
   BasicTrustRegionSQPParameters();
 };
 
-struct BasicTrustRegionSQPUtilFunctions
-{
-  virtual ~BasicTrustRegionSQPUtilFunctions() = default;
-
-  virtual DblVec evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const;
-
-  virtual DblVec evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints, const DblVec& x) const;
-
-  virtual std::vector<ConvexObjective::Ptr> convexifyCosts(const std::vector<Cost::Ptr>& costs,
-                                                           const DblVec& x,
-                                                           Model* model) const;
-
-  virtual std::vector<ConvexConstraints::Ptr> convexifyConstraints(const std::vector<Constraint::Ptr>& cnts,
-                                                                   const DblVec& x,
-                                                                   Model* model) const;
-
-  virtual DblVec evaluateModelCosts(const std::vector<ConvexObjective::Ptr>& costs, const DblVec& x) const;
-
-  virtual DblVec evaluateModelCntViols(const std::vector<ConvexConstraints::Ptr>& cnts, const DblVec& x) const;
-
-  virtual std::vector<std::string> getCostNames(const std::vector<Cost::Ptr>& costs) const;
-
-  virtual std::vector<std::string> getCntNames(const std::vector<Constraint::Ptr>& cnts) const;
-
-  virtual std::vector<std::string> getVarNames(const VarVector& vars) const;
-};
-
-struct BasicTrustRegionSQPUtilFunctionsThreaded : public BasicTrustRegionSQPUtilFunctions
-{
-  BasicTrustRegionSQPUtilFunctionsThreaded();
-  BasicTrustRegionSQPUtilFunctionsThreaded(int num_threads);
-  ~BasicTrustRegionSQPUtilFunctionsThreaded() override = default;
-
-  DblVec evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const override final;
-
-  DblVec evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints, const DblVec& x) const override final;
-
-  std::vector<ConvexObjective::Ptr> convexifyCosts(const std::vector<Cost::Ptr>& costs,
-                                                   const DblVec& x,
-                                                   Model* model) const override final;
-
-  std::vector<ConvexConstraints::Ptr> convexifyConstraints(const std::vector<Constraint::Ptr>& cnts,
-                                                           const DblVec& x,
-                                                           Model* model) const override final;
-
-  DblVec evaluateModelCosts(const std::vector<ConvexObjective::Ptr>& costs, const DblVec& x) const override final;
-
-  DblVec evaluateModelCntViols(const std::vector<ConvexConstraints::Ptr>& cnts, const DblVec& x) const override final;
-
-  std::vector<std::string> getCostNames(const std::vector<Cost::Ptr>& costs) const override final;
-
-  std::vector<std::string> getCntNames(const std::vector<Constraint::Ptr>& cnts) const override final;
-
-  std::vector<std::string> getVarNames(const VarVector& vars) const override final;
-
-private:
-  int num_threads_;
-};
-
 class BasicTrustRegionSQP : public Optimizer
 {
   /*

--- a/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
@@ -3,6 +3,7 @@
 TRAJOPT_IGNORE_WARNINGS_PUSH
 #include <Eigen/Core>
 #include <osqp.h>
+#include <mutex>
 TRAJOPT_IGNORE_WARNINGS_POP
 
 #include <trajopt_sco/solver_interface.hpp>
@@ -75,14 +76,17 @@ class OSQPModel : public Model
 
   OSQPModelConfig config_; /**< The configuration settings */
 
+  std::mutex mutex_; /**< The mutex */
+
 public:
   OSQPModel(const ModelConfig::ConstPtr& config = nullptr);
   ~OSQPModel() override;
   OSQPModel(const OSQPModel& model) = delete;
   OSQPModel& operator=(const OSQPModel& model) = delete;
-  OSQPModel(OSQPModel&&) = default;
-  OSQPModel& operator=(OSQPModel&&) = default;
+  OSQPModel(OSQPModel&&) = delete;
+  OSQPModel& operator=(OSQPModel&&) = delete;
 
+  // Must be threadsafe
   Var addVar(const std::string& name) override;
   Cnt addEqCnt(const AffExpr&, const std::string& name) override;
   Cnt addIneqCnt(const AffExpr&, const std::string& name) override;
@@ -90,13 +94,14 @@ public:
   void removeVars(const VarVector& vars) override;
   void removeCnts(const CntVector& cnts) override;
 
+  // These do not need to be threadsafe
   void update() override;
-  void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper) override;
-  DblVec getVarValues(const VarVector& vars) const override;
   CvxOptStatus optimize() override;
   void setObjective(const AffExpr&) override;
   void setObjective(const QuadExpr&) override;
-  VarVector getVars() const override;
+  void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper) override;
+  DblVec getVarValues(const VarVector& vars) const override;
   void writeToFile(const std::string& fname) const override;
+  VarVector getVars() const override;
 };
 }  // namespace sco

--- a/trajopt_sco/include/trajopt_sco/qpoases_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/qpoases_interface.hpp
@@ -3,6 +3,7 @@
 TRAJOPT_IGNORE_WARNINGS_PUSH
 #include <Eigen/Core>
 #include <qpOASES.hpp>
+#include <mutex>
 TRAJOPT_IGNORE_WARNINGS_POP
 
 #include <trajopt_sco/solver_interface.hpp>
@@ -71,14 +72,17 @@ class qpOASESModel : public Model
 
   QuadExpr objective_; /**< objective QuadExpr expression */
 
+  std::mutex mutex_; /**< The mutex */
+
 public:
   qpOASESModel();
   ~qpOASESModel() override;
-  qpOASESModel(const qpOASESModel&) = default;
-  qpOASESModel& operator=(const qpOASESModel&) = default;
-  qpOASESModel(qpOASESModel&&) = default;
-  qpOASESModel& operator=(qpOASESModel&&) = default;
+  qpOASESModel(const qpOASESModel&) = delete;
+  qpOASESModel& operator=(const qpOASESModel&) = delete;
+  qpOASESModel(qpOASESModel&&) = delete;
+  qpOASESModel& operator=(qpOASESModel&&) = delete;
 
+  // Must be thread safe
   Var addVar(const std::string& name) override;
   Cnt addEqCnt(const AffExpr&, const std::string& name) override;
   Cnt addIneqCnt(const AffExpr&, const std::string& name) override;
@@ -86,12 +90,13 @@ public:
   void removeVars(const VarVector& vars) override;
   void removeCnts(const CntVector& cnts) override;
 
+  // These do not need to be threadsafe
   void update() override;
-  void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper) override;
-  DblVec getVarValues(const VarVector& vars) const override;
   CvxOptStatus optimize() override;
   void setObjective(const AffExpr&) override;
   void setObjective(const QuadExpr&) override;
+  void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper) override;
+  DblVec getVarValues(const VarVector& vars) const override;
   void writeToFile(const std::string& fname) const override;
   VarVector getVars() const override;
 };

--- a/trajopt_sco/include/trajopt_sco/sco_common.hpp
+++ b/trajopt_sco/include/trajopt_sco/sco_common.hpp
@@ -21,6 +21,7 @@ using AffExprVector = std::vector<AffExpr>;
 using QuadExprVector = std::vector<QuadExpr>;
 using CntVector = std::vector<Cnt>;
 
+// NOLINTNEXTLINE
 inline double vecSum(const DblVec& v)
 {
   double out = 0;
@@ -28,6 +29,8 @@ inline double vecSum(const DblVec& v)
     out += i;
   return out;
 }
+
+// NOLINTNEXTLINE
 inline double vecAbsSum(const DblVec& v)
 {
   double out = 0;
@@ -35,8 +38,14 @@ inline double vecAbsSum(const DblVec& v)
     out += fabs(i);
   return out;
 }
+
+// NOLINTNEXTLINE
 inline double pospart(double x) { return (x > 0) ? x : 0; }
+
+// NOLINTNEXTLINE
 inline double sq(double x) { return x * x; }
+
+// NOLINTNEXTLINE
 inline double vecHingeSum(const DblVec& v)
 {
   double out = 0;
@@ -44,7 +53,11 @@ inline double vecHingeSum(const DblVec& v)
     out += pospart(i);
   return out;
 }
+
+// NOLINTNEXTLINE
 inline double vecMax(const DblVec& v) { return *std::max_element(v.begin(), v.end()); }
+
+// NOLINTNEXTLINE
 inline double vecDot(const DblVec& a, const DblVec& b)
 {
   assert(a.size() == b.size());

--- a/trajopt_sco/include/trajopt_sco/solver_interface.hpp
+++ b/trajopt_sco/include/trajopt_sco/solver_interface.hpp
@@ -64,18 +64,31 @@ public:
   Model(Model&&) = default;
   Model& operator=(Model&&) = default;
 
+  /**
+   * @brief Add a var to the model
+   * @details These must be threadsafe
+   */
   virtual Var addVar(const std::string& name) = 0;
   virtual Var addVar(const std::string& name, double lb, double ub);
 
+  /**
+   * @brief Add a equation to the model
+   * @details These must be threadsafe
+   */
   virtual Cnt addEqCnt(const AffExpr&, const std::string& name) = 0;     // expr == 0
   virtual Cnt addIneqCnt(const AffExpr&, const std::string& name) = 0;   // expr <= 0
   virtual Cnt addIneqCnt(const QuadExpr&, const std::string& name) = 0;  // expr <= 0
 
+  /**
+   * @brief Remove items from model
+   * @details These must be threadsafe
+   */
   virtual void removeVar(const Var& var);
   virtual void removeCnt(const Cnt& cnt);
   virtual void removeVars(const VarVector& vars) = 0;
   virtual void removeCnts(const CntVector& cnts) = 0;
 
+  /**  @details It is not neccessary to make the following methods threadsafe */
   virtual void update() = 0;  // call after adding/deleting stuff
   virtual void setVarBounds(const Var& var, double lower, double upper);
   virtual void setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper) = 0;

--- a/trajopt_sco/src/bpmpd_interface.cpp
+++ b/trajopt_sco/src/bpmpd_interface.cpp
@@ -235,6 +235,7 @@ BPMPDModel::BPMPDModel()
 
 Var BPMPDModel::addVar(const std::string& name)
 {
+  std::scoped_lock lock(m_mutex);
   m_vars.push_back(std::make_shared<VarRep>(m_vars.size(), name, this));
   m_lbs.push_back(-BPMPD_BIG);
   m_ubs.push_back(BPMPD_BIG);
@@ -242,6 +243,7 @@ Var BPMPDModel::addVar(const std::string& name)
 }
 Cnt BPMPDModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
+  std::scoped_lock lock(m_mutex);
   m_cnts.push_back(std::make_shared<CntRep>(m_cnts.size(), this));
   m_cntExprs.push_back(expr);
   m_cntTypes.push_back(EQ);
@@ -249,6 +251,7 @@ Cnt BPMPDModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
 }
 Cnt BPMPDModel::addIneqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
+  std::scoped_lock lock(m_mutex);
   m_cnts.push_back(std::make_shared<CntRep>(m_cnts.size(), this));
   m_cntExprs.push_back(expr);
   m_cntTypes.push_back(INEQ);
@@ -261,6 +264,7 @@ Cnt BPMPDModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/)
 
 void BPMPDModel::removeVars(const VarVector& vars)
 {
+  std::scoped_lock lock(m_mutex);
   SizeTVec inds;
   vars2inds(vars, inds);
   for (const auto& var : vars)
@@ -269,6 +273,7 @@ void BPMPDModel::removeVars(const VarVector& vars)
 
 void BPMPDModel::removeCnts(const CntVector& cnts)
 {
+  std::scoped_lock lock(m_mutex);
   SizeTVec inds;
   cnts2inds(cnts, inds);
   for (auto& cnt : cnts)  // NOLINT

--- a/trajopt_sco/src/gurobi_interface.cpp
+++ b/trajopt_sco/src/gurobi_interface.cpp
@@ -83,6 +83,7 @@ GurobiModel::GurobiModel()
 
 Var GurobiModel::addVar(const std::string& name)
 {
+  std::scoped_lock lock(m_mutex);
   ENSURE_SUCCESS(GRBaddvar(
       m_model, 0, nullptr, nullptr, 0, -GRB_INFINITY, GRB_INFINITY, GRB_CONTINUOUS, const_cast<char*>(name.c_str())));
   m_vars.push_back(std::make_shared<VarRep>(m_vars.size(), name, this));
@@ -91,6 +92,7 @@ Var GurobiModel::addVar(const std::string& name)
 
 Var GurobiModel::addVar(const std::string& name, double lb, double ub)
 {
+  std::scoped_lock lock(m_mutex);
   ENSURE_SUCCESS(GRBaddvar(m_model, 0, nullptr, nullptr, 0, lb, ub, GRB_CONTINUOUS, const_cast<char*>(name.c_str())));
   m_vars.push_back(std::make_shared<VarRep>(m_vars.size(), name, this));
   return m_vars.back();
@@ -98,6 +100,7 @@ Var GurobiModel::addVar(const std::string& name, double lb, double ub)
 
 Cnt GurobiModel::addEqCnt(const AffExpr& expr, const std::string& name)
 {
+  std::scoped_lock lock(m_mutex);
   LOG_TRACE("adding eq constraint: %s = 0", CSTR(expr));
   IntVec inds;
   vars2inds(expr.vars, inds);
@@ -115,6 +118,7 @@ Cnt GurobiModel::addEqCnt(const AffExpr& expr, const std::string& name)
 }
 Cnt GurobiModel::addIneqCnt(const AffExpr& expr, const std::string& name)
 {
+  std::scoped_lock lock(m_mutex);
   LOG_TRACE("adding ineq: %s <= 0", CSTR(expr));
   IntVec inds;
   vars2inds(expr.vars, inds);
@@ -132,6 +136,7 @@ Cnt GurobiModel::addIneqCnt(const AffExpr& expr, const std::string& name)
 }
 Cnt GurobiModel::addIneqCnt(const QuadExpr& qexpr, const std::string& name)
 {
+  std::scoped_lock lock(m_mutex);
   int numlnz = static_cast<int>(qexpr.affexpr.size());
   IntVec linds;
   vars2inds(qexpr.affexpr.vars, linds);
@@ -167,6 +172,7 @@ void resetIndices(CntVector& cnts)
 
 void GurobiModel::removeVars(const VarVector& vars)
 {
+  std::scoped_lock lock(m_mutex);
   IntVec inds;
   vars2inds(vars, inds);
   ENSURE_SUCCESS(GRBdelvars(m_model, static_cast<int>(inds.size()), inds.data()));
@@ -176,6 +182,7 @@ void GurobiModel::removeVars(const VarVector& vars)
 
 void GurobiModel::removeCnts(const CntVector& cnts)
 {
+  std::scoped_lock lock(m_mutex);
   IntVec inds;
   cnts2inds(cnts, inds);
   ENSURE_SUCCESS(GRBdelconstrs(m_model, static_cast<int>(inds.size()), inds.data()));

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -710,8 +710,8 @@ OptStatus BasicTrustRegionSQP::optimize()
         ++results_.n_func_evals;
       }
 
-      // DblVec new_cnt_viols = util_funcs_->evaluateConstraintViols(constraints, results_.x);
-      // DblVec new_cost_vals = util_funcs_->evaluateCosts(prob_->getCosts(), results_.x);
+      // DblVec new_cnt_viols = evaluateConstraintViols(constraints, results_.x);
+      // DblVec new_cost_vals = evaluateCosts(prob_->getCosts(), results_.x);
       // cout << "costs" << endl;
       // for (int i=0; i < new_cnt_viols.size(); ++i) {
       //   cout << cnt_names[i] << " " << new_cnt_viols[i] -

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -31,210 +31,6 @@ std::ostream& operator<<(std::ostream& o, const OptResults& r)
   return o;
 }
 
-//////////////////////////////////////////////////
-////////// private utility functions for  sqp /////////
-//////////////////////////////////////////////////
-
-DblVec BasicTrustRegionSQPUtilFunctions::evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const
-{
-  DblVec out(costs.size());
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->value(x);
-
-  return out;
-}
-
-DblVec BasicTrustRegionSQPUtilFunctions::evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints,
-                                                                 const DblVec& x) const
-{
-  DblVec out(constraints.size());
-  for (size_t i = 0; i < constraints.size(); ++i)
-    out[i] = constraints[i]->violation(x);
-
-  return out;
-}
-
-std::vector<ConvexObjective::Ptr> BasicTrustRegionSQPUtilFunctions::convexifyCosts(const std::vector<Cost::Ptr>& costs,
-                                                                                   const DblVec& x,
-                                                                                   Model* model) const
-{
-  std::vector<ConvexObjective::Ptr> out(costs.size());
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->convex(x, model);
-
-  return out;
-}
-
-std::vector<ConvexConstraints::Ptr>
-BasicTrustRegionSQPUtilFunctions::convexifyConstraints(const std::vector<Constraint::Ptr>& cnts,
-                                                       const DblVec& x,
-                                                       Model* model) const
-{
-  std::vector<ConvexConstraints::Ptr> out(cnts.size());
-  for (size_t i = 0; i < cnts.size(); ++i)
-    out[i] = cnts[i]->convex(x, model);
-
-  return out;
-}
-
-DblVec BasicTrustRegionSQPUtilFunctions::evaluateModelCosts(const std::vector<ConvexObjective::Ptr>& costs,
-                                                            const DblVec& x) const
-{
-  DblVec out(costs.size());
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->value(x);
-
-  return out;
-}
-
-DblVec BasicTrustRegionSQPUtilFunctions::evaluateModelCntViols(const std::vector<ConvexConstraints::Ptr>& cnts,
-                                                               const DblVec& x) const
-{
-  DblVec out(cnts.size());
-  for (size_t i = 0; i < cnts.size(); ++i)
-    out[i] = cnts[i]->violation(x);
-
-  return out;
-}
-
-std::vector<std::string> BasicTrustRegionSQPUtilFunctions::getCostNames(const std::vector<Cost::Ptr>& costs) const
-{
-  std::vector<std::string> out(costs.size());
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->name();
-
-  return out;
-}
-
-std::vector<std::string> BasicTrustRegionSQPUtilFunctions::getCntNames(const std::vector<Constraint::Ptr>& cnts) const
-{
-  std::vector<std::string> out(cnts.size());
-  for (size_t i = 0; i < cnts.size(); ++i)
-    out[i] = cnts[i]->name();
-  return out;
-}
-
-std::vector<std::string> BasicTrustRegionSQPUtilFunctions::getVarNames(const VarVector& vars) const
-{
-  std::vector<std::string> out;
-  out.reserve(vars.size());
-  for (const auto& var : vars)
-    out.push_back(var.var_rep->name);
-  return out;
-}
-
-BasicTrustRegionSQPUtilFunctionsThreaded::BasicTrustRegionSQPUtilFunctionsThreaded()
-  : BasicTrustRegionSQPUtilFunctionsThreaded(static_cast<int>(std::thread::hardware_concurrency()))
-{
-}
-BasicTrustRegionSQPUtilFunctionsThreaded::BasicTrustRegionSQPUtilFunctionsThreaded(int num_threads)
-  : num_threads_(num_threads)
-{
-}
-
-DblVec BasicTrustRegionSQPUtilFunctionsThreaded::evaluateCosts(const std::vector<Cost::Ptr>& costs,
-                                                               const DblVec& x) const
-{
-  DblVec out(costs.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < costs.size(); ++i)  // NOLINT
-    out[i] = costs[i]->value(x);          // NOLINT
-
-  return out;
-}
-
-DblVec
-BasicTrustRegionSQPUtilFunctionsThreaded::evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints,
-                                                                  const DblVec& x) const
-{
-  DblVec out(constraints.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < constraints.size(); ++i)  // NOLINT
-    out[i] = constraints[i]->violation(x);      // NOLINT
-
-  return out;
-}
-
-std::vector<ConvexObjective::Ptr>
-BasicTrustRegionSQPUtilFunctionsThreaded::convexifyCosts(const std::vector<Cost::Ptr>& costs,
-                                                         const DblVec& x,
-                                                         Model* model) const
-{
-  std::vector<ConvexObjective::Ptr> out(costs.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < costs.size(); ++i)  // NOLINT
-    out[i] = costs[i]->convex(x, model);  // NOLINT
-
-  return out;
-}
-
-std::vector<ConvexConstraints::Ptr>
-BasicTrustRegionSQPUtilFunctionsThreaded::convexifyConstraints(const std::vector<Constraint::Ptr>& cnts,
-                                                               const DblVec& x,
-                                                               Model* model) const
-{
-  std::vector<ConvexConstraints::Ptr> out(cnts.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < cnts.size(); ++i)  // NOLINT
-    out[i] = cnts[i]->convex(x, model);  // NOLINT
-
-  return out;
-}
-
-DblVec BasicTrustRegionSQPUtilFunctionsThreaded::evaluateModelCosts(const std::vector<ConvexObjective::Ptr>& costs,
-                                                                    const DblVec& x) const
-{
-  DblVec out(costs.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < costs.size(); ++i)  // NOLINT
-    out[i] = costs[i]->value(x);          // NOLINT
-
-  return out;
-}
-
-DblVec BasicTrustRegionSQPUtilFunctionsThreaded::evaluateModelCntViols(const std::vector<ConvexConstraints::Ptr>& cnts,
-                                                                       const DblVec& x) const
-{
-  DblVec out(cnts.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < cnts.size(); ++i)  // NOLINT
-    out[i] = cnts[i]->violation(x);      // NOLINT
-
-  return out;
-}
-
-std::vector<std::string>
-BasicTrustRegionSQPUtilFunctionsThreaded::getCostNames(const std::vector<Cost::Ptr>& costs) const
-{
-  std::vector<std::string> out(costs.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < costs.size(); ++i)  // NOLINT
-    out[i] = costs[i]->name();            // NOLINT
-
-  return out;
-}
-
-std::vector<std::string>
-BasicTrustRegionSQPUtilFunctionsThreaded::getCntNames(const std::vector<Constraint::Ptr>& cnts) const
-{
-  std::vector<std::string> out(cnts.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < cnts.size(); ++i)  // NOLINT
-    out[i] = cnts[i]->name();            // NOLINT
-
-  return out;
-}
-
-std::vector<std::string> BasicTrustRegionSQPUtilFunctionsThreaded::getVarNames(const VarVector& vars) const
-{
-  std::vector<std::string> out(vars.size());
-#pragma omp parallel for num_threads(num_threads_)
-  for (int i = 0; i < vars.size(); ++i)  // NOLINT
-    out[i] = vars[i].var_rep->name;      // NOLINT
-
-  return out;
-}
-
 // todo: use different coeffs for each constraint
 std::vector<ConvexObjective::Ptr> cntsToCosts(const std::vector<ConvexConstraints::Ptr>& cnts,
                                               const std::vector<double>& err_coeffs,
@@ -304,18 +100,13 @@ BasicTrustRegionSQPParameters::BasicTrustRegionSQPParameters()
 
 BasicTrustRegionSQP::BasicTrustRegionSQP(const OptProb::Ptr& prob) { ctor(prob); }
 void BasicTrustRegionSQP::setProblem(OptProb::Ptr prob) { ctor(prob); }
-void BasicTrustRegionSQP::setParameters(const BasicTrustRegionSQPParameters& param)
-{
-  param_ = param;
-  updateUtilsFunctions();
-}
+void BasicTrustRegionSQP::setParameters(const BasicTrustRegionSQPParameters& param) { param_ = param; }
 const BasicTrustRegionSQPParameters& BasicTrustRegionSQP::getParameters() const { return param_; }
 BasicTrustRegionSQPParameters& BasicTrustRegionSQP::getParameters() { return param_; }
 void BasicTrustRegionSQP::ctor(const OptProb::Ptr& prob)
 {
   Optimizer::setProblem(prob);
   model_ = prob->getModel();
-  updateUtilsFunctions();
 }
 
 void BasicTrustRegionSQP::adjustTrustRegion(double ratio) { setTrustRegionSize(param_.trust_box_size * ratio); }
@@ -334,12 +125,192 @@ void BasicTrustRegionSQP::setTrustBoxConstraints(const DblVec& x)
   model_->setVarBounds(vars, lbtrust, ubtrust);
 }
 
-void BasicTrustRegionSQP::updateUtilsFunctions()
+//////////////////////////////////////////////////
+////// protected utility functions for  sqp //////
+//////////////////////////////////////////////////
+
+DblVec BasicTrustRegionSQP::evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const
 {
-  if (param_.num_threads > 1)
-    util_funcs_ = std::make_shared<BasicTrustRegionSQPUtilFunctionsThreaded>(param_.num_threads);
-  else
-    util_funcs_ = std::make_shared<BasicTrustRegionSQPUtilFunctions>();
+  DblVec out(costs.size());
+  for (size_t i = 0; i < costs.size(); ++i)
+    out[i] = costs[i]->value(x);
+
+  return out;
+}
+
+DblVec BasicTrustRegionSQP::evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints,
+                                                    const DblVec& x) const
+{
+  DblVec out(constraints.size());
+  for (size_t i = 0; i < constraints.size(); ++i)
+    out[i] = constraints[i]->violation(x);
+
+  return out;
+}
+
+std::vector<ConvexObjective::Ptr> BasicTrustRegionSQP::convexifyCosts(const std::vector<Cost::Ptr>& costs,
+                                                                      const DblVec& x,
+                                                                      Model* model) const
+{
+  std::vector<ConvexObjective::Ptr> out(costs.size());
+  for (size_t i = 0; i < costs.size(); ++i)
+    out[i] = costs[i]->convex(x, model);
+
+  return out;
+}
+
+std::vector<ConvexConstraints::Ptr> BasicTrustRegionSQP::convexifyConstraints(const std::vector<Constraint::Ptr>& cnts,
+                                                                              const DblVec& x,
+                                                                              Model* model) const
+{
+  std::vector<ConvexConstraints::Ptr> out(cnts.size());
+  for (size_t i = 0; i < cnts.size(); ++i)
+    out[i] = cnts[i]->convex(x, model);
+
+  return out;
+}
+
+DblVec BasicTrustRegionSQP::evaluateModelCosts(const std::vector<ConvexObjective::Ptr>& costs, const DblVec& x) const
+{
+  DblVec out(costs.size());
+  for (size_t i = 0; i < costs.size(); ++i)
+    out[i] = costs[i]->value(x);
+
+  return out;
+}
+
+DblVec BasicTrustRegionSQP::evaluateModelCntViols(const std::vector<ConvexConstraints::Ptr>& cnts,
+                                                  const DblVec& x) const
+{
+  DblVec out(cnts.size());
+  for (size_t i = 0; i < cnts.size(); ++i)
+    out[i] = cnts[i]->violation(x);
+
+  return out;
+}
+
+std::vector<std::string> BasicTrustRegionSQP::getCostNames(const std::vector<Cost::Ptr>& costs) const
+{
+  std::vector<std::string> out(costs.size());
+  for (size_t i = 0; i < costs.size(); ++i)
+    out[i] = costs[i]->name();
+
+  return out;
+}
+
+std::vector<std::string> BasicTrustRegionSQP::getCntNames(const std::vector<Constraint::Ptr>& cnts) const
+{
+  std::vector<std::string> out(cnts.size());
+  for (size_t i = 0; i < cnts.size(); ++i)
+    out[i] = cnts[i]->name();
+  return out;
+}
+
+std::vector<std::string> BasicTrustRegionSQP::getVarNames(const VarVector& vars) const
+{
+  std::vector<std::string> out;
+  out.reserve(vars.size());
+  for (const auto& var : vars)
+    out.push_back(var.var_rep->name);
+  return out;
+}
+
+DblVec BasicTrustRegionSQPMultiThreaded::evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const
+{
+  DblVec out(costs.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(costs.size()); ++i)
+    out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->value(x);
+
+  return out;
+}
+
+DblVec BasicTrustRegionSQPMultiThreaded::evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints,
+                                                                 const DblVec& x) const
+{
+  DblVec out(constraints.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(constraints.size()); ++i)
+    out[static_cast<std::size_t>(i)] = constraints[static_cast<std::size_t>(i)]->violation(x);
+
+  return out;
+}
+
+std::vector<ConvexObjective::Ptr> BasicTrustRegionSQPMultiThreaded::convexifyCosts(const std::vector<Cost::Ptr>& costs,
+                                                                                   const DblVec& x,
+                                                                                   Model* model) const
+{
+  std::vector<ConvexObjective::Ptr> out(costs.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(costs.size()); ++i)
+    out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->convex(x, model);
+
+  return out;
+}
+
+std::vector<ConvexConstraints::Ptr>
+BasicTrustRegionSQPMultiThreaded::convexifyConstraints(const std::vector<Constraint::Ptr>& cnts,
+                                                       const DblVec& x,
+                                                       Model* model) const
+{
+  std::vector<ConvexConstraints::Ptr> out(cnts.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
+    out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->convex(x, model);
+
+  return out;
+}
+
+DblVec BasicTrustRegionSQPMultiThreaded::evaluateModelCosts(const std::vector<ConvexObjective::Ptr>& costs,
+                                                            const DblVec& x) const
+{
+  DblVec out(costs.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(costs.size()); ++i)
+    out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->value(x);
+
+  return out;
+}
+
+DblVec BasicTrustRegionSQPMultiThreaded::evaluateModelCntViols(const std::vector<ConvexConstraints::Ptr>& cnts,
+                                                               const DblVec& x) const
+{
+  DblVec out(cnts.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
+    out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->violation(x);
+
+  return out;
+}
+
+std::vector<std::string> BasicTrustRegionSQPMultiThreaded::getCostNames(const std::vector<Cost::Ptr>& costs) const
+{
+  std::vector<std::string> out(costs.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(costs.size()); ++i)
+    out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->name();
+
+  return out;
+}
+
+std::vector<std::string> BasicTrustRegionSQPMultiThreaded::getCntNames(const std::vector<Constraint::Ptr>& cnts) const
+{
+  std::vector<std::string> out(cnts.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
+    out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->name();
+
+  return out;
+}
+
+std::vector<std::string> BasicTrustRegionSQPMultiThreaded::getVarNames(const VarVector& vars) const
+{
+  std::vector<std::string> out(vars.size());
+#pragma omp parallel for num_threads(param_.num_threads)
+  for (int i = 0; i < static_cast<int>(vars.size()); ++i)
+    out[static_cast<std::size_t>(i)] = vars[static_cast<std::size_t>(i)].var_rep->name;
+
+  return out;
 }
 
 #if 0
@@ -367,11 +338,8 @@ struct MultiCritFilter {
 BasicTrustRegionSQPResults::BasicTrustRegionSQPResults(std::vector<std::string> var_names,
                                                        std::vector<std::string> cost_names,
                                                        std::vector<std::string> cnt_names,
-                                                       std::shared_ptr<BasicTrustRegionSQPUtilFunctions> util_funcs)
-  : var_names(std::move(var_names))
-  , cost_names(std::move(cost_names))
-  , cnt_names(std::move(cnt_names))
-  , util_funcs_(std::move(util_funcs))
+                                                       const BasicTrustRegionSQP& parent)
+  : var_names(std::move(var_names)), cost_names(std::move(cost_names)), cnt_names(std::move(cnt_names)), parent_(parent)
 {
   model_var_vals.clear();
   model_cost_vals.clear();
@@ -401,8 +369,8 @@ void BasicTrustRegionSQPResults::update(const OptResults& prev_opt_results,
 {
   this->merit_error_coeffs = merit_error_coeffs;
   model_var_vals = model.getVarValues(model.getVars());
-  model_cost_vals = util_funcs_->evaluateModelCosts(cost_models, model_var_vals);
-  model_cnt_viols = util_funcs_->evaluateModelCntViols(cnt_models, model_var_vals);
+  model_cost_vals = parent_.evaluateModelCosts(cost_models, model_var_vals);
+  model_cnt_viols = parent_.evaluateModelCntViols(cnt_models, model_var_vals);
 
   // the n variables of the OptProb happen to be the first n variables in
   // the Model
@@ -410,7 +378,7 @@ void BasicTrustRegionSQPResults::update(const OptResults& prev_opt_results,
 
   if (util::GetLogLevel() >= util::LevelDebug)
   {
-    DblVec cnt_costs1 = util_funcs_->evaluateModelCosts(cnt_cost_models, model_var_vals);
+    DblVec cnt_costs1 = parent_.evaluateModelCosts(cnt_cost_models, model_var_vals);
     DblVec cnt_costs2 = model_cnt_viols;
     for (unsigned i = 0; i < cnt_costs2.size(); ++i)
       cnt_costs2[i] *= merit_error_coeffs[i];
@@ -421,8 +389,8 @@ void BasicTrustRegionSQPResults::update(const OptResults& prev_opt_results,
 
   old_cost_vals = prev_opt_results.cost_vals;
   old_cnt_viols = prev_opt_results.cnt_viols;
-  new_cost_vals = util_funcs_->evaluateCosts(costs, new_x);
-  new_cnt_viols = util_funcs_->evaluateConstraintViols(constraints, new_x);
+  new_cost_vals = parent_.evaluateCosts(costs, new_x);
+  new_cnt_viols = parent_.evaluateConstraintViols(constraints, new_x);
 
   old_merit = vecSum(old_cost_vals) + vecDot(old_cnt_viols, merit_error_coeffs);
   model_merit = vecSum(model_cost_vals) + vecDot(model_cnt_viols, merit_error_coeffs);
@@ -704,12 +672,12 @@ void BasicTrustRegionSQPResults::printRaw() const
 
 OptStatus BasicTrustRegionSQP::optimize()
 {
-  std::vector<std::string> var_names = util_funcs_->getVarNames(prob_->getVars());
-  std::vector<std::string> cost_names = util_funcs_->getCostNames(prob_->getCosts());
+  std::vector<std::string> var_names = getVarNames(prob_->getVars());
+  std::vector<std::string> cost_names = getCostNames(prob_->getCosts());
   std::vector<Constraint::Ptr> constraints = prob_->getConstraints();
-  std::vector<std::string> cnt_names = util_funcs_->getCntNames(constraints);
+  std::vector<std::string> cnt_names = getCntNames(constraints);
   std::vector<double> merit_error_coeffs(constraints.size(), param_.initial_merit_error_coeff);
-  BasicTrustRegionSQPResults iteration_results(var_names, cost_names, cnt_names, util_funcs_);
+  BasicTrustRegionSQPResults iteration_results(var_names, cost_names, cnt_names, *this);
 
   std::FILE* log_solver_stream = nullptr;
   std::FILE* log_vars_stream = nullptr;
@@ -766,8 +734,8 @@ OptStatus BasicTrustRegionSQP::optimize()
       // that
       if (results_.cost_vals.empty() && results_.cnt_viols.empty())
       {  // only happens on the first iteration
-        results_.cnt_viols = util_funcs_->evaluateConstraintViols(constraints, results_.x);
-        results_.cost_vals = util_funcs_->evaluateCosts(prob_->getCosts(), results_.x);
+        results_.cnt_viols = evaluateConstraintViols(constraints, results_.x);
+        results_.cost_vals = evaluateCosts(prob_->getCosts(), results_.x);
         assert(results_.n_func_evals == 0);
         ++results_.n_func_evals;
       }
@@ -784,10 +752,8 @@ OptStatus BasicTrustRegionSQP::optimize()
       //   results_.cost_vals[i] << endl;
       // }
 
-      std::vector<ConvexObjective::Ptr> cost_models =
-          util_funcs_->convexifyCosts(prob_->getCosts(), results_.x, model_.get());
-      std::vector<ConvexConstraints::Ptr> cnt_models =
-          util_funcs_->convexifyConstraints(constraints, results_.x, model_.get());
+      std::vector<ConvexObjective::Ptr> cost_models = convexifyCosts(prob_->getCosts(), results_.x, model_.get());
+      std::vector<ConvexConstraints::Ptr> cnt_models = convexifyConstraints(constraints, results_.x, model_.get());
       std::vector<ConvexObjective::Ptr> cnt_cost_models = cntsToCosts(cnt_models, merit_error_coeffs, model_.get());
       model_->update();
       for (ConvexObjective::Ptr& cost : cost_models)

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -137,8 +137,8 @@ DblVec BasicTrustRegionSQPUtilFunctionsThreaded::evaluateCosts(const std::vector
 {
   DblVec out(costs.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->value(x);
+  for (int i = 0; i < costs.size(); ++i)  // NOLINT
+    out[i] = costs[i]->value(x);          // NOLINT
 
   return out;
 }
@@ -149,8 +149,8 @@ BasicTrustRegionSQPUtilFunctionsThreaded::evaluateConstraintViols(const std::vec
 {
   DblVec out(constraints.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < constraints.size(); ++i)
-    out[i] = constraints[i]->violation(x);
+  for (int i = 0; i < constraints.size(); ++i)  // NOLINT
+    out[i] = constraints[i]->violation(x);      // NOLINT
 
   return out;
 }
@@ -162,8 +162,8 @@ BasicTrustRegionSQPUtilFunctionsThreaded::convexifyCosts(const std::vector<Cost:
 {
   std::vector<ConvexObjective::Ptr> out(costs.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->convex(x, model);
+  for (int i = 0; i < costs.size(); ++i)  // NOLINT
+    out[i] = costs[i]->convex(x, model);  // NOLINT
 
   return out;
 }
@@ -175,8 +175,8 @@ BasicTrustRegionSQPUtilFunctionsThreaded::convexifyConstraints(const std::vector
 {
   std::vector<ConvexConstraints::Ptr> out(cnts.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < cnts.size(); ++i)
-    out[i] = cnts[i]->convex(x, model);
+  for (int i = 0; i < cnts.size(); ++i)  // NOLINT
+    out[i] = cnts[i]->convex(x, model);  // NOLINT
 
   return out;
 }
@@ -186,8 +186,8 @@ DblVec BasicTrustRegionSQPUtilFunctionsThreaded::evaluateModelCosts(const std::v
 {
   DblVec out(costs.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->value(x);
+  for (int i = 0; i < costs.size(); ++i)  // NOLINT
+    out[i] = costs[i]->value(x);          // NOLINT
 
   return out;
 }
@@ -197,8 +197,8 @@ DblVec BasicTrustRegionSQPUtilFunctionsThreaded::evaluateModelCntViols(const std
 {
   DblVec out(cnts.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < cnts.size(); ++i)
-    out[i] = cnts[i]->violation(x);
+  for (int i = 0; i < cnts.size(); ++i)  // NOLINT
+    out[i] = cnts[i]->violation(x);      // NOLINT
 
   return out;
 }
@@ -208,8 +208,8 @@ BasicTrustRegionSQPUtilFunctionsThreaded::getCostNames(const std::vector<Cost::P
 {
   std::vector<std::string> out(costs.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < costs.size(); ++i)
-    out[i] = costs[i]->name();
+  for (int i = 0; i < costs.size(); ++i)  // NOLINT
+    out[i] = costs[i]->name();            // NOLINT
 
   return out;
 }
@@ -219,18 +219,18 @@ BasicTrustRegionSQPUtilFunctionsThreaded::getCntNames(const std::vector<Constrai
 {
   std::vector<std::string> out(cnts.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < cnts.size(); ++i)
-    out[i] = cnts[i]->name();
+  for (int i = 0; i < cnts.size(); ++i)  // NOLINT
+    out[i] = cnts[i]->name();            // NOLINT
+
   return out;
 }
 
 std::vector<std::string> BasicTrustRegionSQPUtilFunctionsThreaded::getVarNames(const VarVector& vars) const
 {
   std::vector<std::string> out(vars.size());
-  out.reserve(vars.size());
 #pragma omp parallel for num_threads(num_threads_)
-  for (size_t i = 0; i < vars.size(); ++i)
-    out[i] = vars[i].var_rep->name;
+  for (int i = 0; i < vars.size(); ++i)  // NOLINT
+    out[i] = vars[i].var_rep->name;      // NOLINT
 
   return out;
 }

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -138,12 +138,11 @@ DblVec BasicTrustRegionSQP::evaluateCosts(const std::vector<Cost::Ptr>& costs, c
   return out;
 }
 
-DblVec BasicTrustRegionSQP::evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints,
-                                                    const DblVec& x) const
+DblVec BasicTrustRegionSQP::evaluateConstraintViols(const std::vector<Constraint::Ptr>& cnts, const DblVec& x) const
 {
-  DblVec out(constraints.size());
-  for (size_t i = 0; i < constraints.size(); ++i)
-    out[i] = constraints[i]->violation(x);
+  DblVec out(cnts.size());
+  for (size_t i = 0; i < cnts.size(); ++i)
+    out[i] = cnts[i]->violation(x);
 
   return out;
 }
@@ -218,20 +217,24 @@ std::vector<std::string> BasicTrustRegionSQP::getVarNames(const VarVector& vars)
 DblVec BasicTrustRegionSQPMultiThreaded::evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const
 {
   DblVec out(costs.size());
-#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic) num_threads(param_.num_threads) shared(out, costs, x)
   for (int i = 0; i < static_cast<int>(costs.size()); ++i)
+  {
     out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->value(x);
+  }
 
   return out;
 }
 
-DblVec BasicTrustRegionSQPMultiThreaded::evaluateConstraintViols(const std::vector<Constraint::Ptr>& constraints,
+DblVec BasicTrustRegionSQPMultiThreaded::evaluateConstraintViols(const std::vector<Constraint::Ptr>& cnts,
                                                                  const DblVec& x) const
 {
-  DblVec out(constraints.size());
-#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
-  for (int i = 0; i < static_cast<int>(constraints.size()); ++i)
-    out[static_cast<std::size_t>(i)] = constraints[static_cast<std::size_t>(i)]->violation(x);
+  DblVec out(cnts.size());
+#pragma omp parallel for schedule(dynamic) num_threads(param_.num_threads) shared(out, cnts, x)
+  for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
+  {
+    out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->violation(x);
+  }
 
   return out;
 }
@@ -241,9 +244,11 @@ std::vector<ConvexObjective::Ptr> BasicTrustRegionSQPMultiThreaded::convexifyCos
                                                                                    Model* model) const
 {
   std::vector<ConvexObjective::Ptr> out(costs.size());
-#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic) num_threads(param_.num_threads) shared(out, costs, x, model)
   for (int i = 0; i < static_cast<int>(costs.size()); ++i)
+  {
     out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->convex(x, model);
+  }
 
   return out;
 }
@@ -254,9 +259,11 @@ BasicTrustRegionSQPMultiThreaded::convexifyConstraints(const std::vector<Constra
                                                        Model* model) const
 {
   std::vector<ConvexConstraints::Ptr> out(cnts.size());
-#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic) num_threads(param_.num_threads) shared(out, cnts, x, model)
   for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
+  {
     out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->convex(x, model);
+  }
 
   return out;
 }
@@ -265,9 +272,11 @@ DblVec BasicTrustRegionSQPMultiThreaded::evaluateModelCosts(const std::vector<Co
                                                             const DblVec& x) const
 {
   DblVec out(costs.size());
-#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic) num_threads(param_.num_threads) shared(out, costs, x)
   for (int i = 0; i < static_cast<int>(costs.size()); ++i)
+  {
     out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->value(x);
+  }
 
   return out;
 }
@@ -276,9 +285,11 @@ DblVec BasicTrustRegionSQPMultiThreaded::evaluateModelCntViols(const std::vector
                                                                const DblVec& x) const
 {
   DblVec out(cnts.size());
-#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic) num_threads(param_.num_threads) shared(out, cnts, x)
   for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
+  {
     out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->violation(x);
+  }
 
   return out;
 }

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -218,7 +218,7 @@ std::vector<std::string> BasicTrustRegionSQP::getVarNames(const VarVector& vars)
 DblVec BasicTrustRegionSQPMultiThreaded::evaluateCosts(const std::vector<Cost::Ptr>& costs, const DblVec& x) const
 {
   DblVec out(costs.size());
-#pragma omp parallel for num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
   for (int i = 0; i < static_cast<int>(costs.size()); ++i)
     out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->value(x);
 
@@ -229,7 +229,7 @@ DblVec BasicTrustRegionSQPMultiThreaded::evaluateConstraintViols(const std::vect
                                                                  const DblVec& x) const
 {
   DblVec out(constraints.size());
-#pragma omp parallel for num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
   for (int i = 0; i < static_cast<int>(constraints.size()); ++i)
     out[static_cast<std::size_t>(i)] = constraints[static_cast<std::size_t>(i)]->violation(x);
 
@@ -241,7 +241,7 @@ std::vector<ConvexObjective::Ptr> BasicTrustRegionSQPMultiThreaded::convexifyCos
                                                                                    Model* model) const
 {
   std::vector<ConvexObjective::Ptr> out(costs.size());
-#pragma omp parallel for num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
   for (int i = 0; i < static_cast<int>(costs.size()); ++i)
     out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->convex(x, model);
 
@@ -254,7 +254,7 @@ BasicTrustRegionSQPMultiThreaded::convexifyConstraints(const std::vector<Constra
                                                        Model* model) const
 {
   std::vector<ConvexConstraints::Ptr> out(cnts.size());
-#pragma omp parallel for num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
   for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
     out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->convex(x, model);
 
@@ -265,7 +265,7 @@ DblVec BasicTrustRegionSQPMultiThreaded::evaluateModelCosts(const std::vector<Co
                                                             const DblVec& x) const
 {
   DblVec out(costs.size());
-#pragma omp parallel for num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
   for (int i = 0; i < static_cast<int>(costs.size()); ++i)
     out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->value(x);
 
@@ -276,39 +276,9 @@ DblVec BasicTrustRegionSQPMultiThreaded::evaluateModelCntViols(const std::vector
                                                                const DblVec& x) const
 {
   DblVec out(cnts.size());
-#pragma omp parallel for num_threads(param_.num_threads)
+#pragma omp parallel for schedule(dynamic, 1) num_threads(param_.num_threads)
   for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
     out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->violation(x);
-
-  return out;
-}
-
-std::vector<std::string> BasicTrustRegionSQPMultiThreaded::getCostNames(const std::vector<Cost::Ptr>& costs) const
-{
-  std::vector<std::string> out(costs.size());
-#pragma omp parallel for num_threads(param_.num_threads)
-  for (int i = 0; i < static_cast<int>(costs.size()); ++i)
-    out[static_cast<std::size_t>(i)] = costs[static_cast<std::size_t>(i)]->name();
-
-  return out;
-}
-
-std::vector<std::string> BasicTrustRegionSQPMultiThreaded::getCntNames(const std::vector<Constraint::Ptr>& cnts) const
-{
-  std::vector<std::string> out(cnts.size());
-#pragma omp parallel for num_threads(param_.num_threads)
-  for (int i = 0; i < static_cast<int>(cnts.size()); ++i)
-    out[static_cast<std::size_t>(i)] = cnts[static_cast<std::size_t>(i)]->name();
-
-  return out;
-}
-
-std::vector<std::string> BasicTrustRegionSQPMultiThreaded::getVarNames(const VarVector& vars) const
-{
-  std::vector<std::string> out(vars.size());
-#pragma omp parallel for num_threads(param_.num_threads)
-  for (int i = 0; i < static_cast<int>(vars.size()); ++i)
-    out[static_cast<std::size_t>(i)] = vars[static_cast<std::size_t>(i)].var_rep->name;
 
   return out;
 }

--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -62,6 +62,7 @@ OSQPModel::~OSQPModel()
 
 Var OSQPModel::addVar(const std::string& name)
 {
+  std::scoped_lock lock(mutex_);
   vars_.push_back(std::make_shared<VarRep>(vars_.size(), name, this));
   lbs_.push_back(-OSQP_INFINITY);
   ubs_.push_back(OSQP_INFINITY);
@@ -70,6 +71,7 @@ Var OSQPModel::addVar(const std::string& name)
 
 Cnt OSQPModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
+  std::scoped_lock lock(mutex_);
   cnts_.push_back(std::make_shared<CntRep>(cnts_.size(), this));
   cnt_exprs_.push_back(expr);
   cnt_types_.push_back(EQ);
@@ -78,6 +80,7 @@ Cnt OSQPModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
 
 Cnt OSQPModel::addIneqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
+  std::scoped_lock lock(mutex_);
   cnts_.push_back(std::make_shared<CntRep>(cnts_.size(), this));
   cnt_exprs_.push_back(expr);
   cnt_types_.push_back(INEQ);
@@ -88,6 +91,7 @@ Cnt OSQPModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/) { throw 
 
 void OSQPModel::removeVars(const VarVector& vars)
 {
+  std::scoped_lock lock(mutex_);
   SizeTVec inds;
   vars2inds(vars, inds);
   for (const auto& var : vars)
@@ -96,6 +100,7 @@ void OSQPModel::removeVars(const VarVector& vars)
 
 void OSQPModel::removeCnts(const CntVector& cnts)
 {
+  std::scoped_lock lock(mutex_);
   SizeTVec inds;
   cnts2inds(cnts, inds);
   for (const auto& cnt : cnts)

--- a/trajopt_sco/src/qpoases_interface.cpp
+++ b/trajopt_sco/src/qpoases_interface.cpp
@@ -38,6 +38,7 @@ qpOASESModel::qpOASESModel()
 qpOASESModel::~qpOASESModel() = default;
 Var qpOASESModel::addVar(const std::string& name)
 {
+  std::scoped_lock lock(mutex_);
   vars_.push_back(std::make_shared<VarRep>(vars_.size(), name, this));
   lb_.push_back(-QPOASES_INFTY);
   ub_.push_back(QPOASES_INFTY);
@@ -46,6 +47,7 @@ Var qpOASESModel::addVar(const std::string& name)
 
 Cnt qpOASESModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
+  std::scoped_lock lock(mutex_);
   cnts_.push_back(std::make_shared<CntRep>(cnts_.size(), this));
   cnt_exprs_.push_back(expr);
   cnt_types_.push_back(EQ);
@@ -54,6 +56,7 @@ Cnt qpOASESModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
 
 Cnt qpOASESModel::addIneqCnt(const AffExpr& expr, const std::string& /*name*/)
 {
+  std::scoped_lock lock(mutex_);
   cnts_.push_back(std::make_shared<CntRep>(cnts_.size(), this));
   cnt_exprs_.push_back(expr);
   cnt_types_.push_back(INEQ);
@@ -68,6 +71,7 @@ Cnt qpOASESModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/)
 
 void qpOASESModel::removeVars(const VarVector& vars)
 {
+  std::scoped_lock lock(mutex_);
   IntVec inds;
   vars2inds(vars, inds);
   for (const auto& var : vars)
@@ -76,6 +80,7 @@ void qpOASESModel::removeVars(const VarVector& vars)
 
 void qpOASESModel::removeCnts(const CntVector& cnts)
 {
+  std::scoped_lock lock(mutex_);
   IntVec inds;
   cnts2inds(cnts, inds);
   for (const auto& cnt : cnts)


### PR DESCRIPTION
This replaces #302 and surprised that it was not having issues because the Models themselves needs to be threadsafe. This is why that PR required the omp critical around the addHinge, but does not solve the issue where other constraints are also adding variables and other items to the model which was not threadsafe. 

@marip8 I came up with a way to separate running trajopt with and without multi-threading but not sure if there is a better way. 