### PR TITLE
Fix osqp_eigen_solver hessian and linear constraint matrix.

### DIFF
--- a/trajopt_optimizers/trajopt_sqp/test/numerical_ik_unit.cpp
+++ b/trajopt_optimizers/trajopt_sqp/test/numerical_ik_unit.cpp
@@ -117,10 +117,10 @@ void runNumericalIKTest(const trajopt_sqp::QPProblem::Ptr& qp_problem, const Env
   // 5) Setup solver
   auto qp_solver = std::make_shared<trajopt_sqp::OSQPEigenSolver>();
   trajopt_sqp::TrustRegionSQPSolver solver(qp_solver);
-  qp_solver->solver_.settings()->setVerbosity(true);
+  qp_solver->solver_.settings()->setVerbosity(false);
   qp_solver->solver_.settings()->setWarmStart(true);
   qp_solver->solver_.settings()->setPolish(true);
-  qp_solver->solver_.settings()->setAdaptiveRho(false);
+  qp_solver->solver_.settings()->setAdaptiveRho(true);
   qp_solver->solver_.settings()->setMaxIteration(8192);
   qp_solver->solver_.settings()->setAbsoluteTolerance(1e-4);
   qp_solver->solver_.settings()->setRelativeTolerance(1e-6);


### PR DESCRIPTION
There were several issues found

1. Not correctly using eigen prune
2. Not using pruned matrix in one case 
3. OSQP Eigen uses a different method for populating the CSC Matrix which has a bug if the input is an empty sparse matrix so a work around was implemented to get around the issue until it is fixed upstream
4. Improve debug output to easily compare between Ifopt and Legacy Version
