### PR TITLE
Add toleranced Cartesian waypoints to solver

### DIFF
--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -16,6 +16,8 @@ TRAJOPT_IGNORE_WARNINGS_POP
 
 namespace trajopt
 {
+const double DEFAULT_EPSILON = 1e-5;
+
 using ErrorFunctionType = std::function<Eigen::VectorXd(const Eigen::Isometry3d&, const Eigen::Isometry3d&)>;
 
 /**
@@ -96,6 +98,9 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
    */
   Eigen::VectorXi indices_;
 
+  /** @brief perturbation amount for calculating Jacobian */
+  double epsilon_;
+
   DynamicCartPoseJacCalculator(
       tesseract_kinematics::JointGroup::ConstPtr manip,
       std::string source_frame,
@@ -109,6 +114,7 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
     , target_frame_(std::move(target_frame))
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
+    , epsilon_(DEFAULT_EPSILON)
   {
     assert(indices_.size() <= 6);
   }
@@ -197,6 +203,9 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
    */
   Eigen::VectorXi indices_;
 
+  /** @brief perturbation amount for calculating Jacobian */
+  double epsilon_;
+
   CartPoseJacCalculator(
       tesseract_kinematics::JointGroup::ConstPtr manip,
       std::string source_frame,
@@ -210,6 +219,7 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
     , target_frame_(std::move(target_frame))
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
+    , epsilon_(DEFAULT_EPSILON)
   {
     is_target_active_ = manip_->isActiveLinkName(target_frame_);
     assert(indices_.size() <= 6);

--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -45,7 +45,7 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
 
   /** @brief Error function for calculating the error in the position given the source and target positions
    * this defaults to tesseract_common::calcTransformError if unset*/
-  ErrorFunctionType error_function = nullptr;
+  ErrorFunctionType error_function{ nullptr };
 
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
@@ -62,8 +62,8 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
       Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
-      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
-      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6));
+      Eigen::VectorXd lower_tolerance = {},
+      Eigen::VectorXd upper_tolerance = {});
 
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const Eigen::VectorXd& dof_vals) override;
 
@@ -148,7 +148,7 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
 
   /** @brief Error function for calculating the error in the position given the source and target positions
    * this defaults to tesseract_common::calcTransformError if unset*/
-  ErrorFunctionType error_function_ = nullptr;
+  ErrorFunctionType error_function_{ nullptr };
 
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
@@ -165,8 +165,8 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
       Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
-      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
-      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6));
+      Eigen::VectorXd lower_tolerance = {},
+      Eigen::VectorXd upper_tolerance = {});
 
   void Plot(const tesseract_visualization::Visualization::Ptr& plotter, const Eigen::VectorXd& dof_vals) override;
 

--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -148,7 +148,7 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
 
   /** @brief Error function for calculating the error in the position given the source and target positions
    * this defaults to tesseract_common::calcTransformError if unset*/
-  ErrorFunctionType error_function = nullptr;
+  ErrorFunctionType error_function_ = nullptr;
 
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}

--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -194,13 +194,13 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
       Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
       Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6),
       ErrorFunctionType error_func = nullptr)
-      : manip_(std::move(manip))
-      , source_frame_(std::move(source_frame))
-      , target_frame_(std::move(target_frame))
-      , source_frame_offset_(source_frame_offset)
-      , target_frame_offset_(target_frame_offset)
-      , indices_(std::move(indices))
-      , error_function(error_func)
+    : manip_(std::move(manip))
+    , source_frame_(std::move(source_frame))
+    , target_frame_(std::move(target_frame))
+    , source_frame_offset_(source_frame_offset)
+    , target_frame_offset_(target_frame_offset)
+    , indices_(std::move(indices))
+    , error_function(error_func)
   {
     if (lower_tolerance.size() == 0)
       lower_tolerance_ = Eigen::VectorXd::Zero(6);

--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -15,6 +15,8 @@ TRAJOPT_IGNORE_WARNINGS_POP
 
 namespace trajopt
 {
+using ErrorFunctionType = std::function<Eigen::VectorXd(const Eigen::Isometry3d&, const Eigen::Isometry3d&)>;
+
 /**
  * @brief Used to calculate the error for CartPoseTermInfo
  * This is converted to a cost or constraint using TrajOptCostFromErrFunc or TrajOptConstraintFromErrFunc
@@ -45,6 +47,10 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
    * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
   Eigen::VectorXd upper_tolerance_;
 
+  /** @brief Error function for calculating the error in the position given the source and target positions
+   * this defaults to tesseract_common::calcTransformError if unset*/
+  ErrorFunctionType error_function = nullptr;
+
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -61,13 +67,15 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
       Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
       Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
-      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
+      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6),
+      ErrorFunctionType error_func = nullptr)
     : manip_(std::move(manip))
     , source_frame_(std::move(source_frame))
     , target_frame_(std::move(target_frame))
     , source_frame_offset_(source_frame_offset)
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
+    , error_function(error_func)
   {
     if (lower_tolerance.size() == 0)
       lower_tolerance_ = Eigen::VectorXd::Zero(6);
@@ -105,13 +113,6 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
   /** @brief A offset transform to be applied to target_frame_ location */
   Eigen::Isometry3d target_frame_offset_;
 
-  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
-   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
-  Eigen::VectorXd lower_tolerance_;
-  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
-   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
-  Eigen::VectorXd upper_tolerance_;
-
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -126,9 +127,7 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
-      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
-      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
+      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()))
     : manip_(std::move(manip))
     , source_frame_(std::move(source_frame))
     , source_frame_offset_(source_frame_offset)
@@ -136,14 +135,6 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
   {
-    if (lower_tolerance.size() == 0)
-      lower_tolerance_ = Eigen::VectorXd::Zero(6);
-    else
-      lower_tolerance_ = lower_tolerance;
-    if (upper_tolerance.size() == 0)
-      upper_tolerance_ = Eigen::VectorXd::Zero(6);
-    else
-      upper_tolerance_ = upper_tolerance;
     assert(indices_.size() <= 6);
   }
 
@@ -181,6 +172,10 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
    * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
   Eigen::VectorXd upper_tolerance_;
 
+  /** @brief Error function for calculating the error in the position given the source and target positions
+   * this defaults to tesseract_common::calcTransformError if unset*/
+  ErrorFunctionType error_function = nullptr;
+
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -197,13 +192,15 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
       Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
       Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
-      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
-    : manip_(std::move(manip))
-    , source_frame_(std::move(source_frame))
-    , source_frame_offset_(source_frame_offset)
-    , target_frame_(std::move(target_frame))
-    , target_frame_offset_(target_frame_offset)
-    , indices_(std::move(indices))
+      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6),
+      ErrorFunctionType error_func = nullptr)
+      : manip_(std::move(manip))
+      , source_frame_(std::move(source_frame))
+      , target_frame_(std::move(target_frame))
+      , source_frame_offset_(source_frame_offset)
+      , target_frame_offset_(target_frame_offset)
+      , indices_(std::move(indices))
+      , error_function(error_func)
   {
     if (lower_tolerance.size() == 0)
       lower_tolerance_ = Eigen::VectorXd::Zero(6);
@@ -244,13 +241,6 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
   /** @brief indicates which link is active */
   bool is_target_active_{ true };
 
-  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
-   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
-  Eigen::VectorXd lower_tolerance_;
-  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
-   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
-  Eigen::VectorXd upper_tolerance_;
-
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -265,9 +255,7 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
-      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
-      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
+      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()))
     : manip_(std::move(manip))
     , source_frame_(std::move(source_frame))
     , source_frame_offset_(source_frame_offset)
@@ -275,14 +263,6 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
   {
-    if (lower_tolerance.size() == 0)
-      lower_tolerance_ = Eigen::VectorXd::Zero(6);
-    else
-      lower_tolerance_ = lower_tolerance;
-    if (upper_tolerance.size() == 0)
-      upper_tolerance_ = Eigen::VectorXd::Zero(6);
-    else
-      upper_tolerance_ = upper_tolerance;
     is_target_active_ = manip_->isActiveLinkName(target_frame_);
     assert(indices_.size() <= 6);
   }

--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -38,6 +38,13 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
   /** @brief A offset transform to be applied to target_frame_ location */
   Eigen::Isometry3d target_frame_offset_;
 
+  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
+  Eigen::VectorXd lower_tolerance_;
+  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
+  Eigen::VectorXd upper_tolerance_;
+
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -52,7 +59,9 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()))
+      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
+      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
+      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
     : manip_(std::move(manip))
     , source_frame_(std::move(source_frame))
     , target_frame_(std::move(target_frame))
@@ -60,6 +69,14 @@ struct DynamicCartPoseErrCalculator : public TrajOptVectorOfVector
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
   {
+    if (lower_tolerance.size() == 0)
+      lower_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      lower_tolerance_ = lower_tolerance;
+    if (upper_tolerance.size() == 0)
+      upper_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      upper_tolerance_ = upper_tolerance;
     assert(indices_.size() <= 6);
   }
 
@@ -88,6 +105,13 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
   /** @brief A offset transform to be applied to target_frame_ location */
   Eigen::Isometry3d target_frame_offset_;
 
+  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
+  Eigen::VectorXd lower_tolerance_;
+  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
+  Eigen::VectorXd upper_tolerance_;
+
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -102,7 +126,9 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()))
+      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
+      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
+      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
     : manip_(std::move(manip))
     , source_frame_(std::move(source_frame))
     , source_frame_offset_(source_frame_offset)
@@ -110,6 +136,14 @@ struct DynamicCartPoseJacCalculator : sco::MatrixOfVector
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
   {
+    if (lower_tolerance.size() == 0)
+      lower_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      lower_tolerance_ = lower_tolerance;
+    if (upper_tolerance.size() == 0)
+      upper_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      upper_tolerance_ = upper_tolerance;
     assert(indices_.size() <= 6);
   }
 
@@ -140,6 +174,13 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
   /** @brief indicates which link is active */
   bool is_target_active_{ true };
 
+  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
+  Eigen::VectorXd lower_tolerance_;
+  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
+  Eigen::VectorXd upper_tolerance_;
+
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -154,7 +195,9 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()))
+      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
+      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
+      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
     : manip_(std::move(manip))
     , source_frame_(std::move(source_frame))
     , source_frame_offset_(source_frame_offset)
@@ -162,6 +205,14 @@ struct CartPoseErrCalculator : public TrajOptVectorOfVector
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
   {
+    if (lower_tolerance.size() == 0)
+      lower_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      lower_tolerance_ = lower_tolerance;
+    if (upper_tolerance.size() == 0)
+      upper_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      upper_tolerance_ = upper_tolerance;
     is_target_active_ = manip_->isActiveLinkName(target_frame_);
     assert(indices_.size() <= 6);
   }
@@ -193,6 +244,13 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
   /** @brief indicates which link is active */
   bool is_target_active_{ true };
 
+  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
+  Eigen::VectorXd lower_tolerance_;
+  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
+  Eigen::VectorXd upper_tolerance_;
+
   /**
    * @brief This is a vector of indices to be returned Default: {0, 1, 2, 3, 4, 5}
    *
@@ -207,7 +265,9 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()))
+      Eigen::VectorXi indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
+      Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
+      Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6))
     : manip_(std::move(manip))
     , source_frame_(std::move(source_frame))
     , source_frame_offset_(source_frame_offset)
@@ -215,6 +275,14 @@ struct CartPoseJacCalculator : sco::MatrixOfVector
     , target_frame_offset_(target_frame_offset)
     , indices_(std::move(indices))
   {
+    if (lower_tolerance.size() == 0)
+      lower_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      lower_tolerance_ = lower_tolerance;
+    if (upper_tolerance.size() == 0)
+      upper_tolerance_ = Eigen::VectorXd::Zero(6);
+    else
+      upper_tolerance_ = upper_tolerance;
     is_target_active_ = manip_->isActiveLinkName(target_frame_);
     assert(indices_.size() <= 6);
   }

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -302,6 +302,10 @@ struct DynamicCartPoseTermInfo : public TermInfo
    * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
   Eigen::VectorXd upper_tolerance;
 
+  /** @brief Error function for calculating the error in the position given the source and target positions
+   * this defaults to tesseract_common::calcTransformError if unset*/
+  std::function<Eigen::VectorXd(const Eigen::Isometry3d&, const Eigen::Isometry3d&)> error_function = nullptr;
+
   DynamicCartPoseTermInfo();
 
   /** @brief Used to add term to pci from json */
@@ -337,6 +341,10 @@ struct CartPoseTermInfo : public TermInfo
   /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
    * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
   Eigen::VectorXd upper_tolerance;
+
+  /** @brief Error function for calculating the error in the position given the source and target positions
+   * this defaults to tesseract_common::calcTransformError if unset*/
+  std::function<Eigen::VectorXd(const Eigen::Isometry3d&, const Eigen::Isometry3d&)> error_function = nullptr;
 
   CartPoseTermInfo();
 

--- a/trajopt/include/trajopt/problem_description.hpp
+++ b/trajopt/include/trajopt/problem_description.hpp
@@ -295,6 +295,12 @@ struct DynamicCartPoseTermInfo : public TermInfo
   Eigen::Isometry3d source_frame_offset;
   /** @brief A Static transform to be applied to target_ location */
   Eigen::Isometry3d target_frame_offset;
+  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
+  Eigen::VectorXd lower_tolerance;
+  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
+  Eigen::VectorXd upper_tolerance;
 
   DynamicCartPoseTermInfo();
 
@@ -325,6 +331,12 @@ struct CartPoseTermInfo : public TermInfo
   Eigen::Isometry3d source_frame_offset;
   /** @brief A Static transform to be applied to target_ location */
   Eigen::Isometry3d target_frame_offset;
+  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
+  Eigen::VectorXd lower_tolerance;
+  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
+  Eigen::VectorXd upper_tolerance;
 
   CartPoseTermInfo();
 

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -37,7 +37,8 @@ Eigen::VectorXd calculateExceededTolerance(const Eigen::VectorXd& lower_toleranc
   Eigen::VectorXd resultant(error.size());
 
   // Iterate through each element
-  for (int i = 0; i < error.size(); ++i) {
+  for (int i = 0; i < error.size(); ++i)
+  {
     // If error is within tolerances, set resultant to 0
     if (error(i) >= lower_tolerance(i) && error(i) <= upper_tolerance(i))
     {

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -29,36 +29,6 @@ using Eigen::VectorXd;
 
 namespace trajopt
 {
-Eigen::VectorXd calculateExceededTolerance(const Eigen::VectorXd& lower_tolerance,
-                                           const Eigen::VectorXd& upper_tolerance,
-                                           const Eigen::VectorXd& error)
-{
-  // Initialize the resultant vector
-  Eigen::VectorXd resultant(error.size());
-
-  // Iterate through each element
-  for (int i = 0; i < error.size(); ++i)
-  {
-    // If error is within tolerances, set resultant to 0
-    if (error(i) >= lower_tolerance(i) && error(i) <= upper_tolerance(i))
-    {
-      resultant(i) = 0.0;
-    }
-    // If error is below lower tolerance, set resultant to error - lower_tolerance
-    else if (error(i) < lower_tolerance(i))
-    {
-      resultant(i) = error(i) - lower_tolerance(i);
-    }
-    // If error is above upper tolerance, set resultant to error - upper_tolerance
-    else if (error(i) > upper_tolerance(i))
-    {
-      resultant(i) = error(i) - upper_tolerance(i);
-    }
-  }
-
-  return resultant;
-}
-
 VectorXd DynamicCartPoseErrCalculator::operator()(const VectorXd& dof_vals) const
 {
   tesseract_common::TransformMap state = manip_->calcFwdKin(dof_vals);

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -31,43 +31,42 @@ namespace trajopt
 {
 // Function to apply tolerances to error values
 Eigen::VectorXd applyTolerances(const Eigen::VectorXd& error,
-                                       const Eigen::VectorXd& lower_tolerance,
-                                       const Eigen::VectorXd& upper_tolerance)
+                                const Eigen::VectorXd& lower_tolerance,
+                                const Eigen::VectorXd& upper_tolerance)
 {
   Eigen::VectorXd resultant(error.size());
 
-     // Iterate through each element
-     for (int i = 0; i < error.size(); ++i)
-     {
-       // If error is within tolerances, set resultant to 0
-       if (error(i) >= lower_tolerance(i) && error(i) <= upper_tolerance(i))
-       {
-         resultant(i) = 0.0;
-       }
-       // If error is below lower tolerance, set resultant to error - lower_tolerance
-       else if (error(i) < lower_tolerance(i))
-       {
-         resultant(i) = error(i) - lower_tolerance(i);
-       }
-       // If error is above upper tolerance, set resultant to error - upper_tolerance
-       else if (error(i) > upper_tolerance(i))
-       {
-         resultant(i) = error(i) - upper_tolerance(i);
-       }
-     }
+  // Iterate through each element
+  for (int i = 0; i < error.size(); ++i)
+  {
+    // If error is within tolerances, set resultant to 0
+    if (error(i) >= lower_tolerance(i) && error(i) <= upper_tolerance(i))
+    {
+      resultant(i) = 0.0;
+    }
+    // If error is below lower tolerance, set resultant to error - lower_tolerance
+    else if (error(i) < lower_tolerance(i))
+    {
+      resultant(i) = error(i) - lower_tolerance(i);
+    }
+    // If error is above upper tolerance, set resultant to error - upper_tolerance
+    else if (error(i) > upper_tolerance(i))
+    {
+      resultant(i) = error(i) - upper_tolerance(i);
+    }
+  }
 
-     return resultant;
+  return resultant;
 }
 
-DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
-    tesseract_kinematics::JointGroup::ConstPtr manip,
-    std::string source_frame,
-    std::string target_frame,
-    const Eigen::Isometry3d& source_frame_offset,
-    const Eigen::Isometry3d& target_frame_offset,
-    Eigen::VectorXi indices,
-    Eigen::VectorXd lower_tolerance,
-    Eigen::VectorXd upper_tolerance)
+DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(tesseract_kinematics::JointGroup::ConstPtr manip,
+                                                           std::string source_frame,
+                                                           std::string target_frame,
+                                                           const Eigen::Isometry3d& source_frame_offset,
+                                                           const Eigen::Isometry3d& target_frame_offset,
+                                                           Eigen::VectorXi indices,
+                                                           Eigen::VectorXd lower_tolerance,
+                                                           Eigen::VectorXd upper_tolerance)
   : manip_(std::move(manip))
   , source_frame_(std::move(source_frame))
   , target_frame_(std::move(target_frame))
@@ -80,8 +79,7 @@ DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
   // Check to see if the waypoint is toleranced and set the error function accordingly
   if ((lower_tolerance.size() == 0 && upper_tolerance.size() == 0) || lower_tolerance.isApprox(upper_tolerance, 1e-6))
   {
-    error_function = [this](const Eigen::Isometry3d& source_tf,
-                            const Eigen::Isometry3d& target_tf) -> Eigen::VectorXd {
+    error_function = [this](const Eigen::Isometry3d& source_tf, const Eigen::Isometry3d& target_tf) -> Eigen::VectorXd {
       return tesseract_common::calcTransformError(source_tf, target_tf);
     };
   }
@@ -162,15 +160,14 @@ MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) cons
   return reduced_jac;  // This is available in 3.4 jac0(indices_, Eigen::all);
 }
 
-CartPoseErrCalculator::CartPoseErrCalculator(
-    tesseract_kinematics::JointGroup::ConstPtr manip,
-    std::string source_frame,
-    std::string target_frame,
-    const Eigen::Isometry3d& source_frame_offset,
-    const Eigen::Isometry3d& target_frame_offset,
-    Eigen::VectorXi indices,
-    Eigen::VectorXd lower_tolerance,
-    Eigen::VectorXd upper_tolerance)
+CartPoseErrCalculator::CartPoseErrCalculator(tesseract_kinematics::JointGroup::ConstPtr manip,
+                                             std::string source_frame,
+                                             std::string target_frame,
+                                             const Eigen::Isometry3d& source_frame_offset,
+                                             const Eigen::Isometry3d& target_frame_offset,
+                                             Eigen::VectorXi indices,
+                                             Eigen::VectorXd lower_tolerance,
+                                             Eigen::VectorXd upper_tolerance)
   : manip_(std::move(manip))
   , source_frame_(std::move(source_frame))
   , target_frame_(std::move(target_frame))
@@ -183,8 +180,7 @@ CartPoseErrCalculator::CartPoseErrCalculator(
   // Check to see if the waypoint is toleranced and set the error function accordingly
   if ((lower_tolerance.size() == 0 && upper_tolerance.size() == 0) || lower_tolerance.isApprox(upper_tolerance, 1e-6))
   {
-    error_function = [this](const Eigen::Isometry3d& source_tf,
-                            const Eigen::Isometry3d& target_tf) -> Eigen::VectorXd {
+    error_function = [this](const Eigen::Isometry3d& source_tf, const Eigen::Isometry3d& target_tf) -> Eigen::VectorXd {
       return tesseract_common::calcTransformError(source_tf, target_tf);
     };
   }
@@ -243,8 +239,7 @@ void CartPoseErrCalculator::Plot(const tesseract_visualization::Visualization::P
 MatrixXd CartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
 {
   // Duplicated from calcForwardNumJac in trajopt_sco/src/num_diff.cpp, but with ignoring tolerances
-  auto calc_error = [this](const VectorXd& vals) -> VectorXd
-  {
+  auto calc_error = [this](const VectorXd& vals) -> VectorXd {
     tesseract_common::TransformMap state = manip_->calcFwdKin(vals);
     Isometry3d source_tf = state[source_frame_] * source_frame_offset_;
     Isometry3d target_tf = state[target_frame_] * target_frame_offset_;

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -175,6 +175,7 @@ CartPoseErrCalculator::CartPoseErrCalculator(tesseract_kinematics::JointGroup::C
   , indices_(std::move(indices))
 {
   assert(indices_.size() <= 6);
+  is_target_active_ = manip_->isActiveLinkName(target_frame_);
 
   // Check to see if the waypoint is toleranced and set the error function accordingly
   if ((lower_tolerance.size() == 0 && upper_tolerance.size() == 0) || lower_tolerance.isApprox(upper_tolerance, 1e-6))

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -180,7 +180,8 @@ CartPoseErrCalculator::CartPoseErrCalculator(tesseract_kinematics::JointGroup::C
   // Check to see if the waypoint is toleranced and set the error function accordingly
   if ((lower_tolerance.size() == 0 && upper_tolerance.size() == 0) || lower_tolerance.isApprox(upper_tolerance, 1e-6))
   {
-    error_function_ = [this](const Eigen::Isometry3d& source_tf, const Eigen::Isometry3d& target_tf) -> Eigen::VectorXd {
+    error_function_ = [this](const Eigen::Isometry3d& source_tf,
+                             const Eigen::Isometry3d& target_tf) -> Eigen::VectorXd {
       return tesseract_common::calcTransformError(source_tf, target_tf);
     };
   }

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -35,15 +35,7 @@ VectorXd DynamicCartPoseErrCalculator::operator()(const VectorXd& dof_vals) cons
   Isometry3d source_tf = state[source_frame_] * source_frame_offset_;
   Isometry3d target_tf = state[target_frame_] * target_frame_offset_;
 
-  VectorXd err;
-  if (!error_function)
-  {
-    err = tesseract_common::calcTransformError(target_tf, source_tf);
-  }
-  else
-  {
-    err = error_function(target_tf, source_tf);
-  }
+  VectorXd err = error_function(target_tf, source_tf);
 
   VectorXd reduced_err(indices_.size());
   for (int i = 0; i < indices_.size(); ++i)
@@ -132,20 +124,10 @@ VectorXd CartPoseErrCalculator::operator()(const VectorXd& dof_vals) const
   Isometry3d target_tf = state[target_frame_] * target_frame_offset_;
 
   VectorXd err;
-  if (!error_function)
-  {
-    if (is_target_active_)
-      err = tesseract_common::calcTransformError(source_tf, target_tf);
-    else
-      err = tesseract_common::calcTransformError(target_tf, source_tf);
-  }
+  if (is_target_active_)
+    err = error_function(source_tf, target_tf);
   else
-  {
-    if (is_target_active_)
-      err = error_function(source_tf, target_tf);
-    else
-      err = error_function(target_tf, source_tf);
-  }
+    err = error_function(target_tf, source_tf);
 
   VectorXd reduced_err(indices_.size());
   for (int i = 0; i < indices_.size(); ++i)

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -34,46 +34,22 @@ Eigen::VectorXd applyTolerances(const Eigen::VectorXd& error,
                                        const Eigen::VectorXd& lower_tolerance,
                                        const Eigen::VectorXd& upper_tolerance)
 {
-//  // Calculate the distance from the lower and upper tolerance, clamping values within tolerance to zero
-//  Eigen::VectorXd dist_from_lower = (lower_tolerance - err).cwiseMax(0);
-//  Eigen::VectorXd dist_from_upper = (err - upper_tolerance).cwiseMax(0);
+  // Calculate the distance from the lower and upper tolerance, clamping values within tolerance to zero
+  Eigen::VectorXd dist_from_lower = (error - lower_tolerance).cwiseMin(0);
+  Eigen::VectorXd dist_from_upper = (error - upper_tolerance).cwiseMax(0);
 
-//  // Use array expressions for element-wise absolute value and comparison
-//  Eigen::ArrayXd dist_from_lower_abs = dist_from_lower.array().abs();
-//  Eigen::ArrayXd dist_from_upper_abs = dist_from_upper.array().abs();
+  // Use array expressions for element-wise absolute value and comparison
+  Eigen::ArrayXd dist_from_lower_abs = dist_from_lower.array().abs();
+  Eigen::ArrayXd dist_from_upper_abs = dist_from_upper.array().abs();
 
-//  // Select the worst error (the one furthest from the tolerance zone) while preserving the sign
-//  Eigen::ArrayXd worst_error_array =
-//      (dist_from_upper_abs > dist_from_lower_abs).select(dist_from_upper.array(), dist_from_lower.array());
+  // Select the worst error (the one furthest from the tolerance zone) while preserving the sign
+  Eigen::ArrayXd worst_error_array =
+      (dist_from_upper_abs > dist_from_lower_abs).select(dist_from_upper.array(), dist_from_lower.array());
 
-//  // Convert the result back to a vector
-//  Eigen::VectorXd worst_error = worst_error_array.matrix();
+  // Convert the result back to a vector
+  Eigen::VectorXd worst_error = worst_error_array.matrix();
 
-//  return worst_error;
-  // Initialize the resultant vector
-   Eigen::VectorXd resultant(error.size());
-
-   // Iterate through each element
-   for (int i = 0; i < error.size(); ++i)
-   {
-     // If error is within tolerances, set resultant to 0
-     if (error(i) >= lower_tolerance(i) && error(i) <= upper_tolerance(i))
-     {
-       resultant(i) = 0.0;
-     }
-     // If error is below lower tolerance, set resultant to error - lower_tolerance
-     else if (error(i) < lower_tolerance(i))
-     {
-       resultant(i) = error(i) - lower_tolerance(i);
-     }
-     // If error is above upper tolerance, set resultant to error - upper_tolerance
-     else if (error(i) > upper_tolerance(i))
-     {
-       resultant(i) = error(i) - upper_tolerance(i);
-     }
-   }
-
-   return resultant;
+  return worst_error;
 }
 
 DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -784,7 +784,8 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
                                                             target_frame_offset,
                                                             indices,
                                                             lower_tolerance,
-                                                            upper_tolerance);
+                                                            upper_tolerance,
+                                                            error_function);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(prob.GetKin(),
@@ -792,9 +793,7 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
                                                                target_frame,
                                                                source_frame_offset,
                                                                target_frame_offset,
-                                                               indices,
-                                                               lower_tolerance,
-                                                               upper_tolerance);
+                                                               indices);
 
     // Apply error calculator as either cost or constraint
     if (term_type & TT_COST)
@@ -939,7 +938,8 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      target_frame_offset,
                                                      indices,
                                                      lower_tolerance,
-                                                     upper_tolerance);
+                                                     upper_tolerance,
+                                                     error_function);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
@@ -947,9 +947,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                         target_frame,
                                                         source_frame_offset,
                                                         target_frame_offset,
-                                                        indices,
-                                                        lower_tolerance,
-                                                        upper_tolerance);
+                                                        indices);
     prob.addCost(
         std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
@@ -962,7 +960,8 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      target_frame_offset,
                                                      indices,
                                                      lower_tolerance,
-                                                     upper_tolerance);
+                                                     upper_tolerance,
+                                                     error_function);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
@@ -970,9 +969,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                         target_frame,
                                                         source_frame_offset,
                                                         target_frame_offset,
-                                                        indices,
-                                                        lower_tolerance,
-                                                        upper_tolerance);
+                                                        indices);
     prob.addConstraint(
         std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -778,11 +778,11 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
   else
   {
     auto f = std::make_shared<DynamicCartPoseErrCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
 
     // Apply error calculator as either cost or constraint
     if (term_type & TT_COST)
@@ -921,22 +921,22 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   else if ((term_type & TT_COST) && ~(term_type | ~TT_USE_TIME))
   {
     auto f = std::make_shared<CartPoseErrCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
     prob.addCost(
         std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
   else if ((term_type & TT_CNT) && ~(term_type | ~TT_USE_TIME))
   {
     auto f = std::make_shared<CartPoseErrCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
     prob.addConstraint(
         std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -939,7 +939,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addCost(
-        std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
+        std::make_shared<TrajOptCostFromErrFunc>(f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
   else if ((term_type & TT_CNT) && ~(term_type | ~TT_USE_TIME))
   {
@@ -956,7 +956,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
-        f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+        f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }
   else
   {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -798,8 +798,8 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
     }
     else if (term_type & TT_CNT)
     {
-      prob.addConstraint(
-          std::make_shared<TrajOptConstraintFromErrFunc>(f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+      prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
+          f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
     }
     else
     {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -784,8 +784,7 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
                                                             target_frame_offset,
                                                             indices,
                                                             lower_tolerance,
-                                                            upper_tolerance,
-                                                            error_function);
+                                                            upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(
@@ -795,12 +794,12 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
     if (term_type & TT_COST)
     {
       prob.addCost(
-          std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
+          std::make_shared<TrajOptCostFromErrFunc>(f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
     }
     else if (term_type & TT_CNT)
     {
-      prob.addConstraint(
-          std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+      prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
+          f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
     }
     else
     {
@@ -934,14 +933,13 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      target_frame_offset,
                                                      indices,
                                                      lower_tolerance,
-                                                     upper_tolerance,
-                                                     error_function);
+                                                     upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addCost(
-        std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
+        std::make_shared<TrajOptCostFromErrFunc>(f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
   else if ((term_type & TT_CNT) && ~(term_type | ~TT_USE_TIME))
   {
@@ -952,14 +950,13 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      target_frame_offset,
                                                      indices,
                                                      lower_tolerance,
-                                                     upper_tolerance,
-                                                     error_function);
+                                                     upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
-    prob.addConstraint(
-        std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+    prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
+        f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }
   else
   {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -799,7 +799,7 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
     else if (term_type & TT_CNT)
     {
       prob.addConstraint(
-          std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+          std::make_shared<TrajOptConstraintFromErrFunc>(f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
     }
     else
     {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -788,12 +788,8 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
                                                             error_function);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
-    auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(prob.GetKin(),
-                                                               source_frame,
-                                                               target_frame,
-                                                               source_frame_offset,
-                                                               target_frame_offset,
-                                                               indices);
+    auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
 
     // Apply error calculator as either cost or constraint
     if (term_type & TT_COST)
@@ -942,12 +938,8 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      error_function);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
-    auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
-                                                        source_frame,
-                                                        target_frame,
-                                                        source_frame_offset,
-                                                        target_frame_offset,
-                                                        indices);
+    auto dfdx = std::make_shared<CartPoseJacCalculator>(
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addCost(
         std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
@@ -964,12 +956,8 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      error_function);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
-    auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
-                                                        source_frame,
-                                                        target_frame,
-                                                        source_frame_offset,
-                                                        target_frame_offset,
-                                                        indices);
+    auto dfdx = std::make_shared<CartPoseJacCalculator>(
+        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addConstraint(
         std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -777,12 +777,24 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
   }
   else
   {
-    auto f = std::make_shared<DynamicCartPoseErrCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
+    auto f = std::make_shared<DynamicCartPoseErrCalculator>(prob.GetKin(),
+                                                            source_frame,
+                                                            target_frame,
+                                                            source_frame_offset,
+                                                            target_frame_offset,
+                                                            indices,
+                                                            lower_tolerance,
+                                                            upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
-    auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
+    auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(prob.GetKin(),
+                                                               source_frame,
+                                                               target_frame,
+                                                               source_frame_offset,
+                                                               target_frame_offset,
+                                                               indices,
+                                                               lower_tolerance,
+                                                               upper_tolerance);
 
     // Apply error calculator as either cost or constraint
     if (term_type & TT_COST)
@@ -920,23 +932,47 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
   }
   else if ((term_type & TT_COST) && ~(term_type | ~TT_USE_TIME))
   {
-    auto f = std::make_shared<CartPoseErrCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
+    auto f = std::make_shared<CartPoseErrCalculator>(prob.GetKin(),
+                                                     source_frame,
+                                                     target_frame,
+                                                     source_frame_offset,
+                                                     target_frame_offset,
+                                                     indices,
+                                                     lower_tolerance,
+                                                     upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
-    auto dfdx = std::make_shared<CartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
+    auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
+                                                        source_frame,
+                                                        target_frame,
+                                                        source_frame_offset,
+                                                        target_frame_offset,
+                                                        indices,
+                                                        lower_tolerance,
+                                                        upper_tolerance);
     prob.addCost(
         std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
   else if ((term_type & TT_CNT) && ~(term_type | ~TT_USE_TIME))
   {
-    auto f = std::make_shared<CartPoseErrCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
+    auto f = std::make_shared<CartPoseErrCalculator>(prob.GetKin(),
+                                                     source_frame,
+                                                     target_frame,
+                                                     source_frame_offset,
+                                                     target_frame_offset,
+                                                     indices,
+                                                     lower_tolerance,
+                                                     upper_tolerance);
 
     // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
-    auto dfdx = std::make_shared<CartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower_tolerance, upper_tolerance);
+    auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
+                                                        source_frame,
+                                                        target_frame,
+                                                        source_frame_offset,
+                                                        target_frame_offset,
+                                                        indices,
+                                                        lower_tolerance,
+                                                        upper_tolerance);
     prob.addConstraint(
         std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -786,7 +786,6 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
                                                             lower_tolerance,
                                                             upper_tolerance);
 
-    // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
 
@@ -935,7 +934,6 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      lower_tolerance,
                                                      upper_tolerance);
 
-    // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addCost(
@@ -952,7 +950,6 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      lower_tolerance,
                                                      upper_tolerance);
 
-    // This is currently not being used. There is an intermittent bug that needs to be tracked down it is not used.
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -798,8 +798,8 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
     }
     else if (term_type & TT_CNT)
     {
-      prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
-          f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+      prob.addConstraint(
+          std::make_shared<TrajOptConstraintFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
     }
     else
     {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -799,7 +799,7 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
     else if (term_type & TT_CNT)
     {
       prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
-          f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+          f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
     }
     else
     {
@@ -939,7 +939,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addCost(
-        std::make_shared<TrajOptCostFromErrFunc>(f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
+        std::make_shared<TrajOptCostFromErrFunc>(f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
   else if ((term_type & TT_CNT) && ~(term_type | ~TT_USE_TIME))
   {
@@ -956,7 +956,7 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
     auto dfdx = std::make_shared<CartPoseJacCalculator>(
         prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
     prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
-        f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
+        f, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }
   else
   {

--- a/trajopt/test/kinematic_costs_unit.cpp
+++ b/trajopt/test/kinematic_costs_unit.cpp
@@ -79,7 +79,8 @@ TEST_F(KinematicCostsTest, CartPoseJacCalculator)  // NOLINT
   std::string source_frame = env_->getRootLinkName();
   std::string target_frame = "r_gripper_tool_frame";
   Eigen::Isometry3d source_frame_offset = env_->getState().link_transforms.at(target_frame);
-  Eigen::Isometry3d target_frame_offset = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d target_frame_offset =
+      Eigen::Isometry3d::Identity() * Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitZ());
 
   Eigen::VectorXd values(7);
   values << -1.1, 1.2, -3.3, -1.4, 5.5, -1.6, 7.7;

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -23,12 +23,9 @@ enum OptStatus
   OPT_FAILED,
   INVALID
 };
-static const std::array<std::string, 6> OptStatus_strings = { "CONVERGED",
-                                                              "SCO_ITERATION_LIMIT",
-                                                              "PENALTY_ITERATION_LIMIT",
-                                                              "TIME_LIMI",
-                                                              "FAILED",
-                                                              "INVALID" };
+static const std::array<std::string, 6> OptStatus_strings = {
+  "CONVERGED", "SCO_ITERATION_LIMIT", "PENALTY_ITERATION_LIMIT", "TIME_LIMI", "FAILED", "INVALID"
+};
 inline std::string statusToString(OptStatus status) { return OptStatus_strings[status]; }
 struct OptResults
 {

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -24,7 +24,7 @@ enum OptStatus
   INVALID
 };
 static const std::array<std::string, 6> OptStatus_strings = {
-  "CONVERGED", "SCO_ITERATION_LIMIT", "PENALTY_ITERATION_LIMIT", "TIME_LIMI", "FAILED", "INVALID"
+  "OPT_CONVERGED", "OPT_SCO_ITERATION_LIMIT", "OPT_PENALTY_ITERATION_LIMIT", "OPT_TIME_LIMIT", "OPT_FAILED", "INVALID"
 };
 inline std::string statusToString(OptStatus status) { return OptStatus_strings[status]; }
 struct OptResults

--- a/trajopt_sco/include/trajopt_sco/optimizers.hpp
+++ b/trajopt_sco/include/trajopt_sco/optimizers.hpp
@@ -23,9 +23,10 @@ enum OptStatus
   OPT_FAILED,
   INVALID
 };
-static const std::array<std::string, 5> OptStatus_strings = { "CONVERGED",
+static const std::array<std::string, 6> OptStatus_strings = { "CONVERGED",
                                                               "SCO_ITERATION_LIMIT",
                                                               "PENALTY_ITERATION_LIMIT",
+                                                              "TIME_LIMI",
                                                               "FAILED",
                                                               "INVALID" };
 inline std::string statusToString(OptStatus status) { return OptStatus_strings[status]; }


### PR DESCRIPTION
This is to support tolerances on Cartesian waypoints so that you can set constraints that don't have to match perfectly