### PR TITLE
Removed gcc-specific option from clang config 

### DIFF
--- a/trajopt_common/include/trajopt_common/macros.h
+++ b/trajopt_common/include/trajopt_common/macros.h
@@ -9,14 +9,13 @@
 #if defined(__clang__)
 #define TRAJOPT_IGNORE_WARNINGS_PUSH				                                                                           \
   _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wall\"")                                           \
-     _Pragma("GCC diagnostic ignored \"-Wint-to-pointer-cast\"")		                                                   \
-         _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")		                                                   \
-             _Pragma("GCC diagnostic ignored \"-Winconsistent-missing-override\"")	                                   \
-                 _Pragma("GCC diagnostic ignored \"-Wconversion\"")			                                               \
-                     _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")		                                       \
-                         _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")                                    \
-                             _Pragma("GCC diagnostic ignored \"-Wclass-memaccess\"")                                   \
-                                 _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
+      _Pragma("GCC diagnostic ignored \"-Wint-to-pointer-cast\"")		                                                   \
+          _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")		                                                 \
+              _Pragma("GCC diagnostic ignored \"-Winconsistent-missing-override\"")	                                   \
+                  _Pragma("GCC diagnostic ignored \"-Wconversion\"")			                                             \
+                      _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")		                                     \
+                          _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")                                   \
+                              _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
 #else
 #define TRAJOPT_IGNORE_WARNINGS_PUSH                                                                                   \
   _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wall\"")                                           \


### PR DESCRIPTION
See https://github.com/tesseract-robotics/tesseract/commit/43d08870034e85a3f335d37ded00df282e5ec46e