### PR TITLE
Handle solver failures like TrajOpt does

### DIFF
--- a/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/qp_problem.h
+++ b/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/qp_problem.h
@@ -56,7 +56,7 @@ public:
   /** @brief Set the current Optimization variables */
   virtual void setVariables(const double* x) = 0;
 
-  /** @brief Set the current Optimization variable values */
+  /** @brief Get the current Optimization variable values */
   virtual Eigen::VectorXd getVariableValues() const = 0;
 
   /** @brief Run the full convexification routine */

--- a/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/types.h
+++ b/trajopt_optimizers/trajopt_sqp/include/trajopt_sqp/types.h
@@ -72,6 +72,8 @@ struct SQPParameters
   double cnt_tolerance = 1e-4;
   /** @brief Max number of times the constraints will be inflated */
   double max_merit_coeff_increases = 5;
+  /** @brief Max number of times the QP solver can fail before optimization is aborted */
+  int max_qp_solver_failures = 3;
   /** @brief Constraints are scaled by this amount when inflated */
   double merit_coeff_increase_ratio = 10;
   /** @brief Max time in seconds that the optimizer will run */

--- a/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
@@ -275,21 +275,21 @@ bool OSQPEigenSolver::updateGradient(const Eigen::Ref<const Eigen::VectorXd>& gr
 
 bool OSQPEigenSolver::updateLowerBound(const Eigen::Ref<const Eigen::VectorXd>& lowerBound)
 {
-  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -OSQP_INFTY);
+  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -INFINITY);
   return solver_.updateLowerBound(bounds_lower_);
 }
 
 bool OSQPEigenSolver::updateUpperBound(const Eigen::Ref<const Eigen::VectorXd>& upperBound)
 {
-  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * OSQP_INFTY);
+  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * INFINITY);
   return solver_.updateUpperBound(bounds_upper_);
 }
 
 bool OSQPEigenSolver::updateBounds(const Eigen::Ref<const Eigen::VectorXd>& lowerBound,
                                    const Eigen::Ref<const Eigen::VectorXd>& upperBound)
 {
-  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -OSQP_INFTY);
-  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * OSQP_INFTY);
+  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -INFINITY);
+  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * INFINITY);
 
   if (solver_.isInitialized())
     return solver_.updateBounds(bounds_lower_, bounds_upper_);

--- a/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
@@ -275,21 +275,21 @@ bool OSQPEigenSolver::updateGradient(const Eigen::Ref<const Eigen::VectorXd>& gr
 
 bool OSQPEigenSolver::updateLowerBound(const Eigen::Ref<const Eigen::VectorXd>& lowerBound)
 {
-  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -INFINITY);
+  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -OSQP_INFTY);
   return solver_.updateLowerBound(bounds_lower_);
 }
 
 bool OSQPEigenSolver::updateUpperBound(const Eigen::Ref<const Eigen::VectorXd>& upperBound)
 {
-  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * INFINITY);
+  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * OSQP_INFTY);
   return solver_.updateUpperBound(bounds_upper_);
 }
 
 bool OSQPEigenSolver::updateBounds(const Eigen::Ref<const Eigen::VectorXd>& lowerBound,
                                    const Eigen::Ref<const Eigen::VectorXd>& upperBound)
 {
-  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -INFINITY);
-  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * INFINITY);
+  bounds_lower_ = lowerBound.cwiseMax(Eigen::VectorXd::Ones(num_cnts_) * -OSQP_INFTY);
+  bounds_upper_ = upperBound.cwiseMin(Eigen::VectorXd::Ones(num_cnts_) * OSQP_INFTY);
 
   if (solver_.isInitialized())
     return solver_.updateBounds(bounds_lower_, bounds_upper_);

--- a/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
@@ -98,7 +98,7 @@ void TrustRegionSQPSolver::solve(const QPProblem::Ptr& qp_problem)
     results_.convexify_iteration = 0;
 
     // Convexification loop
-    for (int convex_iteration = 0; convex_iteration < 100; convex_iteration++)
+    for (int convex_iteration = 1; convex_iteration < 100; convex_iteration++)
     {
       double elapsed_time = std::chrono::duration<double, std::milli>(Clock::now() - start_time).count() / 1000.0;
       if (elapsed_time > params.max_time)
@@ -412,7 +412,7 @@ void TrustRegionSQPSolver::printStepInfo() const
   std::printf("\n| %s |\n", std::string(88, '=').c_str());
   std::printf("| %s %s %s |\n", std::string(36, ' ').c_str(), "ROS Industrial", std::string(36, ' ').c_str());
   std::printf(
-      "| %s %s %s |\n", std::string(32, ' ').c_str(), "TrajOpt Ifopt Motion Planning", std::string(31, ' ').c_str());
+      "| %s %s %s |\n", std::string(28, ' ').c_str(), "TrajOpt Ifopt Motion Planning", std::string(29, ' ').c_str());
   std::printf("| %s |\n", std::string(88, '=').c_str());
   std::printf("| %s %s (Box Size: %-3.9f) %s |\n",
               std::string(26, ' ').c_str(),

--- a/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
@@ -383,6 +383,8 @@ SQPStatus TrustRegionSQPSolver::solveQPProblem()
   }
   else
   {
+    qp_problem->setVariables(results_.best_var_vals.data());
+
     CONSOLE_BRIDGE_logError("Solver Failure");
     return SQPStatus::QP_SOLVER_ERROR;
   }

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -360,99 +360,106 @@ void BasicTrustRegionSQPResults::update(const OptResults& prev_opt_results,
 void BasicTrustRegionSQPResults::print() const
 {
   // Print Header
-  std::printf("\n| %s |\n", std::string(75, '=').c_str());
-  std::printf("| %s %s %s |\n", std::string(29, ' ').c_str(), "ROS Industrial", std::string(30, ' ').c_str());
-  std::printf("| %s %s %s |\n", std::string(25, ' ').c_str(), "TrajOpt Motion Planning", std::string(25, ' ').c_str());
-  std::printf("| %s |\n", std::string(75, '=').c_str());
+  std::printf("\n| %s |\n", std::string(88, '=').c_str());
+  std::printf("| %s %s %s |\n", std::string(36, ' ').c_str(), "ROS Industrial", std::string(36, ' ').c_str());
+  std::printf("| %s %s %s |\n", std::string(31, ' ').c_str(), "TrajOpt Motion Planning", std::string(31, ' ').c_str());
+  std::printf("| %s |\n", std::string(88, '=').c_str());
 
   // Print Cost and Constraint Data
-  std::printf("| %10s | %10s | %10s | %10s | %10s | %10s | -%15s \n",
+  std::printf("| %10s | %10s | %10s | %10s | %10s | %10s | %10s |\n",
               "merit",
               "oldexact",
               "new_exact",
+              "new_approx",
               "dapprox",
               "dexact",
-              "ratio",
-              "");
-  std::printf("| %s | COSTS\n", std::string(75, '-').c_str());
+              "ratio");
+  std::printf("| %s | COSTS\n", std::string(88, '-').c_str());
   for (size_t i = 0; i < old_cost_vals.size(); ++i)
   {
     double approx_improve = old_cost_vals[i] - model_cost_vals[i];
     double exact_improve = old_cost_vals[i] - new_cost_vals[i];
     if (fabs(approx_improve) > 1e-8)
-      std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %-15s \n",
+      std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %-15s \n",
                   "----------",
                   old_cost_vals[i],
                   new_cost_vals[i],
+                  model_cost_vals[i],
                   approx_improve,
                   exact_improve,
                   exact_improve / approx_improve,
                   cost_names[i].c_str());
     else
-      std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10.3e | %10s | %-15s \n",
+      std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10s | %-15s \n",
                   "----------",
                   old_cost_vals[i],
                   new_cost_vals[i],
+                  model_cost_vals[i],
                   approx_improve,
                   exact_improve,
-                  "  ------  ",
+                  "----------",
                   cost_names[i].c_str());
   }
-  std::printf("| %s |\n", std::string(75, '=').c_str());
-  std::printf("| %10s | %10.3e | %10.3e | %10s | %10s | %10s | SUM COSTS \n",
+  std::printf("| %s |\n", std::string(88, '=').c_str());
+  std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10s | %10s | %10s | SUM COSTS\n",
               "----------",
               vecSum(old_cost_vals),
               vecSum(new_cost_vals),
-              "  ------  ",
-              "  ------  ",
-              "  ------  ");
-  std::printf("| %s |\n", std::string(75, '=').c_str());
+              vecSum(model_cost_vals),
+              "----------",
+              "----------",
+              "----------");
+  std::printf("| %s |\n", std::string(88, '=').c_str());
 
   if (!cnt_names.empty())
   {
-    std::printf("| %s | CONSTRAINTS\n", std::string(75, '-').c_str());
+    std::printf("| %s | CONSTRAINTS\n", std::string(88, '-').c_str());
     for (size_t i = 0; i < old_cnt_viols.size(); ++i)
     {
       double approx_improve = old_cnt_viols[i] - model_cnt_viols[i];
       double exact_improve = old_cnt_viols[i] - new_cnt_viols[i];
       if (fabs(approx_improve) > 1e-8)
-        std::printf("| %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %-15s \n",
+        std::printf("| %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %-15s \n",
                     merit_error_coeffs[i],
                     merit_error_coeffs[i] * old_cnt_viols[i],
                     merit_error_coeffs[i] * new_cnt_viols[i],
+                    merit_error_coeffs[i] * model_cnt_viols[i],
                     merit_error_coeffs[i] * approx_improve,
                     merit_error_coeffs[i] * exact_improve,
                     exact_improve / approx_improve,
                     cnt_names[i].c_str());
       else
-        std::printf("| %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10s | %-15s \n",
+        std::printf("| %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10s | %-15s \n",
                     merit_error_coeffs[i],
                     merit_error_coeffs[i] * old_cnt_viols[i],
                     merit_error_coeffs[i] * new_cnt_viols[i],
+                    merit_error_coeffs[i] * model_cnt_viols[i],
                     merit_error_coeffs[i] * approx_improve,
                     merit_error_coeffs[i] * exact_improve,
-                    "  ------  ",
+                    "----------",
                     cnt_names[i].c_str());
     }
   }
-  std::printf("| %s |\n", std::string(75, '=').c_str());
-  std::printf("| %10s | %10.3e | %10.3e | %10s | %10s | %10s | SUM CONSTRAINTS (WITHOUT MERIT) \n",
+  std::printf("| %s |\n", std::string(88, '=').c_str());
+  std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10s | %10s | %10s | SUM CONSTRAINTS (WITHOUT MERIT) \n",
               "----------",
               vecSum(old_cnt_viols),
               vecSum(new_cnt_viols),
-              "  ------  ",
-              "  ------  ",
-              "  ------  ");
-  std::printf("| %s |\n", std::string(75, '=').c_str());
-  std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | TOTAL = SUM COSTS + SUM CONSTRAINTS (WITH "
+              vecSum(model_cnt_viols),
+              "----------",
+              "----------",
+              "----------");
+  std::printf("| %s |\n", std::string(88, '=').c_str());
+  std::printf("| %10s | %10.3e | %10.3e | %10s | %10.3e | %10.3e | %10.3e | TOTAL = SUM COSTS + SUM CONSTRAINTS (WITH "
               "MERIT)\n",
               "----------",
               old_merit,
               new_merit,
+              "----------",
               approx_merit_improve,
               exact_merit_improve,
               merit_improve_ratio);
-  std::printf("| %s |\n", std::string(75, '=').c_str());
+  std::printf("| %s |\n", std::string(88, '=').c_str());
 }
 
 void BasicTrustRegionSQPResults::writeSolver(std::FILE* stream, bool header) const

--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -362,7 +362,7 @@ void BasicTrustRegionSQPResults::print() const
   // Print Header
   std::printf("\n| %s |\n", std::string(88, '=').c_str());
   std::printf("| %s %s %s |\n", std::string(36, ' ').c_str(), "ROS Industrial", std::string(36, ' ').c_str());
-  std::printf("| %s %s %s |\n", std::string(31, ' ').c_str(), "TrajOpt Motion Planning", std::string(31, ' ').c_str());
+  std::printf("| %s %s %s |\n", std::string(32, ' ').c_str(), "TrajOpt Motion Planning", std::string(31, ' ').c_str());
   std::printf("| %s |\n", std::string(88, '=').c_str());
 
   // Print Cost and Constraint Data

--- a/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt_sco/src/osqp_interface.cpp
@@ -343,8 +343,8 @@ CvxOptStatus OSQPModel::optimize()
     {
       Eigen::IOFormat format(5);
       Eigen::Map<Eigen::VectorXd> solution_vec(solution_.data(), static_cast<Eigen::Index>(solution_.size()));
-      std::cout << "OSQP Solution: " << solution_vec.transpose().format(format) << std::endl;
       std::cout << "OSQP Status Value: " << status << std::endl;
+      std::cout << "OSQP Solution: " << solution_vec.transpose().format(format) << std::endl;
     }
 
     if (status == OSQP_SOLVED || status == OSQP_SOLVED_INACCURATE)


### PR DESCRIPTION
- Added max_qp_solver_failures parameter and the logic of TrajOpt to handle solver failures
- Added updateBounds() call after each box size modification
- Moved setVariables() call after a solver failure to solveQPProblem()
- Renamed SQPStatus::TIME_LIMIT to SQPStatus::OPT_TIME_LIMIT because of a name collision with OSQP (in tesseract_planning)

Closes #368