### PR TITLE
Update to vcpkg-action@v6 and use vcpkg-binarycache

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
         path: target_ws/src
 
     - name: vcpkg build
-      uses: johnwason/vcpkg-action@v4
+      uses: johnwason/vcpkg-action@v6
       with:
         pkgs: >-
          fcl bullet3[multithreading,double-precision,rtti] octomap console-bridge eigen3 yaml-cpp 
@@ -37,6 +37,7 @@ jobs:
         token: ${{ github.token }}
         cache-key: ci-${{ matrix.os }}
         revision: 2023.08.09
+        github-binarycache: true
 
     - name: configure-msvc
       uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
Update to v6 of vcpkg-action. v6 optionally uses the new built-in GitHub caching for vcpkg to provide more accurate caching.