### PR TITLE
Remove unneeded reserve() calls

### DIFF
--- a/trajopt_sco/include/trajopt_sco/expr_ops.hpp
+++ b/trajopt_sco/include/trajopt_sco/expr_ops.hpp
@@ -24,9 +24,7 @@ inline void exprInc(AffExpr& a, double b) { a.constant += b; }
 inline void exprInc(AffExpr& a, const AffExpr& b)
 {
   a.constant += b.constant;
-  a.coeffs.reserve(a.coeffs.size() + b.coeffs.size());
   a.coeffs.insert(a.coeffs.end(), b.coeffs.begin(), b.coeffs.end());
-  a.vars.reserve(a.vars.size() + b.vars.size());
   a.vars.insert(a.vars.end(), b.vars.begin(), b.vars.end());
 }
 inline void exprInc(AffExpr& a, const Var& b) { exprInc(a, AffExpr(b)); }
@@ -36,11 +34,8 @@ inline void exprInc(QuadExpr& a, const AffExpr& b) { exprInc(a.affexpr, b); }
 inline void exprInc(QuadExpr& a, const QuadExpr& b)
 {
   exprInc(a.affexpr, b.affexpr);
-  a.coeffs.reserve(a.coeffs.size() + b.coeffs.size());
   a.coeffs.insert(a.coeffs.end(), b.coeffs.begin(), b.coeffs.end());
-  a.vars1.reserve(a.vars1.size() + b.vars1.size());
   a.vars1.insert(a.vars1.end(), b.vars1.begin(), b.vars1.end());
-  a.vars2.reserve(a.vars2.size() + b.vars2.size());
   a.vars2.insert(a.vars2.end(), b.vars2.begin(), b.vars2.end());
 }
 


### PR DESCRIPTION
In expr_ops.hpp reserve() was called at every variable update. This causes the variable and coefficient vectors to be relocated very often, as their size is updated by a minimal amount every time . Removing the reserve() calls allows the vectors to use their normal growing behavior, improving performance.

Before:
![image](https://github.com/tesseract-robotics/trajopt/assets/1153434/c948e2ca-69ba-4e89-b371-3df5a452c03b)

After:
![image](https://github.com/tesseract-robotics/trajopt/assets/1153434/b8e150e1-84d1-4770-a0a8-1ee6488aefd1)
