### PR TITLE
Add trajopt_ifopt builds for Windows and MacOS

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -83,7 +83,7 @@ jobs:
         export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}
 
         colcon build --merge-install \
-            --packages-ignore tesseract_examples trajopt_ifopt trajopt_sqp ifopt vhacd tesseract_python \
+            --packages-ignore tesseract_examples vhacd tesseract_python \
             --event-handlers console_cohesion+ \
             --cmake-force-configure \
             --cmake-args -GNinja -DCMAKE_BUILD_TYPE=Release \
@@ -103,6 +103,6 @@ jobs:
         export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}
 
         colcon test --merge-install \
-            --packages-ignore tesseract_examples trajopt_ifopt trajopt_sqp ifopt vhacd tesseract_python \
+            --packages-ignore tesseract_examples vhacd tesseract_python \
             --event-handlers console_cohesion+
     

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -88,7 +88,7 @@ jobs:
             --event-handlers console_cohesion+ \
             --cmake-force-configure \
             --cmake-args -GNinja -DCMAKE_BUILD_TYPE=Release \
-            -DINSTALL_OMPL=OFF -DINSTALL_OMPL_TAG=master -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF \
+            -DINSTALL_OMPL=OFF -DINSTALL_OMPL_TAG=master -DBUILD_IPOPT=ON -DBUILD_SNOPT=OFF \
             -DBUILD_SHARED_LIBS=ON -DTESSERACT_ENABLE_EXAMPLES=OFF \
             -DVCPKG_APPLOCAL_DEPS=OFF -DTRAJOPT_ENABLE_TESTING=ON \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -28,6 +28,7 @@ env:
     fcl ompl taskflow
     bullet3[multithreading,double-precision,rtti]
     ccd[double-precision] gperftools
+    coin-or-ipopt
 
 jobs:
   build-macos:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,6 +61,6 @@ jobs:
       with:
         ccache-prefix: ${{ matrix.distro }}
         vcs-file: .github/workflows/windows_dependencies.repos
-        upstream-args: --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF
+        upstream-args: --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DBUILD_IPOPT=ON -DBUILD_SNOPT=OFF
         target-path: target_ws/src
         target-args: --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DTRAJOPT_ENABLE_TESTING=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,6 +38,7 @@ jobs:
          benchmark tinyxml2 assimp orocos-kdl pcl lapack-reference boost-dll boost-filesystem boost-filesystem 
          boost-format
          boost-serialization boost-program-options boost-graph urdfdom ccd[double-precision] gtest jsoncpp
+         coin-or-ipopt
         triplet: x64-windows-release
         extra-args: --clean-after-build
         token: ${{ github.token }}
@@ -62,5 +63,4 @@ jobs:
         vcs-file: .github/workflows/windows_dependencies.repos
         upstream-args: --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF
         target-path: target_ws/src
-        target-args: --packages-ignore trajopt_ifopt trajopt_sqp --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DTRAJOPT_ENABLE_TESTING=ON
-        run-tests-args: --packages-ignore trajopt_ifopt trajopt_sqp
+        target-args: --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DTRAJOPT_ENABLE_TESTING=ON


### PR DESCRIPTION
Thanks to @traversaro the `coin-or-ipopt` package is now available on vcpkg, allowing for `trajopt_ifopt` to build on Windows and MacOS. The builds are currently failing. I think the problem on Windows is someone is importing Windows.h which includes a lot of conflicting macros. The conflicting macros include `min()` and `max()`. We can try using `NOMINMAX` to work around this, but I think there are a few other name conflicts causing problems.