### PR TITLE
Fix cpack typo to use trajopt_common over trajopt_utils

### DIFF
--- a/trajopt/CMakeLists.txt
+++ b/trajopt/CMakeLists.txt
@@ -114,7 +114,7 @@ if(TRAJOPT_PACKAGE)
     "libconsole-bridge-dev"
     "libjsoncpp-dev"
     "${TRAJOPT_PACKAGE_PREFIX}trajopt-sco"
-    "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils"
+    "${TRAJOPT_PACKAGE_PREFIX}trajopt-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-environment"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-visualization"
     WINDOWS_DEPENDS
@@ -123,7 +123,7 @@ if(TRAJOPT_PACKAGE)
     "console-bridge"
     "jsoncpp"
     "${TRAJOPT_PACKAGE_PREFIX}trajopt-sco"
-    "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils"
+    "${TRAJOPT_PACKAGE_PREFIX}trajopt-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-environment"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-visualization")
 endif()

--- a/trajopt_ifopt/CMakeLists.txt
+++ b/trajopt_ifopt/CMakeLists.txt
@@ -120,13 +120,13 @@ if(TRAJOPT_PACKAGE)
     "libboost-dev"
     "libconsole-bridge-dev"
     "ifopt"
-    "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils"
+    "${TRAJOPT_PACKAGE_PREFIX}trajopt-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-environment"
     WINDOWS_DEPENDS
     "Eigen3"
     "boost"
     "console-bridge"
     "ifopt"
-    "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils"
+    "${TRAJOPT_PACKAGE_PREFIX}trajopt-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-environment")
 endif()

--- a/trajopt_optimizers/trajopt_sqp/CMakeLists.txt
+++ b/trajopt_optimizers/trajopt_sqp/CMakeLists.txt
@@ -131,7 +131,7 @@ if(TRAJOPT_PACKAGE)
     "ifopt"
     "${TRAJOPT_PACKAGE_PREFIX}osqpeigen"
     "${TRAJOPT_PACKAGE_PREFIX}trajopt-ifopt"
-    "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils"
+    "${TRAJOPT_PACKAGE_PREFIX}trajopt-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-visualization"
     WINDOWS_DEPENDS
@@ -141,7 +141,7 @@ if(TRAJOPT_PACKAGE)
     "ifopt"
     "${TRAJOPT_PACKAGE_PREFIX}osqpeigen"
     "${TRAJOPT_PACKAGE_PREFIX}trajopt-ifopt"
-    "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils"
+    "${TRAJOPT_PACKAGE_PREFIX}trajopt-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-common"
     "${TESSERACT_PACKAGE_PREFIX}tesseract-visualization")
 endif()

--- a/trajopt_sco/CMakeLists.txt
+++ b/trajopt_sco/CMakeLists.txt
@@ -157,12 +157,12 @@ if(TRAJOPT_PACKAGE)
       "libeigen3-dev"
       "libboost-dev"
       "libjsoncpp-dev"
-      "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils")
+      "${TRAJOPT_PACKAGE_PREFIX}trajopt-common")
   set(WINDOWS_DEPENDS
       "Eigen3"
       "boost"
       "jsoncpp"
-      "${TRAJOPT_PACKAGE_PREFIX}trajopt-utils")
+      "${TRAJOPT_PACKAGE_PREFIX}trajopt-common")
 
   if(GUROBI_FOUND)
     # TODO


### PR DESCRIPTION
Dependencies were still referencing "trajopt-utils" even though that package was replaced with "trajopt-common". Updated to fix cpack building.