### PR TITLE
Removed weighted sum methods from legacy Trajopt

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -30,29 +30,7 @@ enum class CollisionExpressionEvaluatorType : std::uint8_t
   START_FREE_END_FREE = 0,  /**< @brief Both start and end state variables are free to be adjusted */
   START_FREE_END_FIXED = 1, /**< @brief Only start state variables are free to be adjusted */
   START_FIXED_END_FREE = 2, /**< @brief Only end state variables are free to be adjusted */
-
-  /**
-   * @brief Both start and end state variables are free to be adjusted
-   * The jacobian is calculated using a weighted sum over the interpolated states for a given link pair.
-   */
-  START_FREE_END_FREE_WEIGHTED_SUM = 3,
-  /**
-   * @brief Only start state variables are free to be adjusted
-   * The jacobian is calculated using a weighted sum over the interpolated states for a given link pair.
-   */
-  START_FREE_END_FIXED_WEIGHTED_SUM = 4,
-  /**
-   * @brief Only end state variables are free to be adjusted
-   * The jacobian is calculated using a weighted sum over the interpolated states for a given link pair.
-   */
-  START_FIXED_END_FREE_WEIGHTED_SUM = 5,
-
-  SINGLE_TIME_STEP = 6, /**< @brief Expressions are only calculated at a single time step */
-  /**
-   * @brief Expressions are only calculated at a single time step
-   * The jacobian is calculated using a weighted sum for a given link pair.
-   */
-  SINGLE_TIME_STEP_WEIGHTED_SUM = 7
+  SINGLE_TIME_STEP = 3,     /**< @brief Expressions are only calculated at a single time step */
 };
 
 /** @brief A data structure to contain a links gradient results */
@@ -266,23 +244,6 @@ protected:
                                        const DblVec& x,
                                        bool isTimestep1);
 
-  void CollisionsToDistanceExpressionsW(sco::AffExprVector& exprs,
-                                        std::vector<double>& exprs_margin,
-                                        std::vector<double>& exprs_coeff,
-                                        const tesseract_collision::ContactResultMap& dist_results,
-                                        const sco::VarVector& vars,
-                                        const DblVec& x,
-                                        bool isTimestep1);
-
-  void CollisionsToDistanceExpressionsContinuousW(sco::AffExprVector& exprs,
-                                                  std::vector<double>& exprs_margin,
-                                                  std::vector<double>& exprs_coeff,
-                                                  const tesseract_collision::ContactResultMap& dist_results,
-                                                  const sco::VarVector& vars0,
-                                                  const sco::VarVector& vars1,
-                                                  const DblVec& x,
-                                                  bool isTimestep1);
-
   /**
    * @brief Calculate the distance expressions when the start is free but the end is fixed
    * This creates an expression for every contact results found.
@@ -320,42 +281,6 @@ protected:
                                    std::vector<double>& exprs_coeff);
 
   /**
-   * @brief Calculate the distance expressions when the start is free but the end is fixed
-   * This creates the expression based on the weighted sum for given link pair
-   * @param x The current values
-   * @param exprs The returned expression
-   * @param exprs_data The safety margin pair associated with the expression
-   */
-  void CalcDistExpressionsStartFreeW(const DblVec& x,
-                                     sco::AffExprVector& exprs,
-                                     std::vector<double>& exprs_margin,
-                                     std::vector<double>& exprs_coeff);
-
-  /**
-   * @brief Calculate the distance expressions when the end is free but the start is fixed
-   * This creates the expression based on the weighted sum for given link pair
-   * @param x The current values
-   * @param exprs The returned expression
-   * @param exprs_data The safety margin pair associated with the expression
-   */
-  void CalcDistExpressionsEndFreeW(const DblVec& x,
-                                   sco::AffExprVector& exprs,
-                                   std::vector<double>& exprs_margin,
-                                   std::vector<double>& exprs_coeff);
-
-  /**
-   * @brief Calculate the distance expressions when the start and end are free
-   * This creates the expression based on the weighted sum for given link pair
-   * @param x The current values
-   * @param exprs The returned expression
-   * @param exprs_data The safety margin pair associated with the expression
-   */
-  void CalcDistExpressionsBothFreeW(const DblVec& x,
-                                    sco::AffExprVector& exprs,
-                                    std::vector<double>& exprs_margin,
-                                    std::vector<double>& exprs_coeff);
-
-  /**
    * @brief Calculate the distance expressions for single time step
    * This creates an expression for every contact results found.
    * @param x The current values
@@ -366,18 +291,6 @@ protected:
                                          sco::AffExprVector& exprs,
                                          std::vector<double>& exprs_margin,
                                          std::vector<double>& exprs_coeff);
-
-  /**
-   * @brief Calculate the distance expressions for single time step
-   * This creates the expression based on the weighted sum for given link pair
-   * @param x The current values
-   * @param exprs The returned expression
-   * @param exprs_data The safety margin pair associated with the expression
-   */
-  void CalcDistExpressionsSingleTimeStepW(const DblVec& x,
-                                          sco::AffExprVector& exprs,
-                                          std::vector<double>& exprs_margin,
-                                          std::vector<double>& exprs_coeff);
 
   /**
    * @brief Remove any results that are invalid.

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -1605,9 +1605,7 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value
   int collision_evaluator_type{ 1 };
   double longest_valid_segment_length{ 0.5 };
   double collision_margin_buffer{ 0.5 };
-  bool use_weighted_sum{ false };
   json_marshal::childFromJson(params, collision_evaluator_type, "evaluator_type", 1);
-  json_marshal::childFromJson(params, use_weighted_sum, "use_weighted_sum", false);
   json_marshal::childFromJson(params, first_step, "first_step", 0);
   json_marshal::childFromJson(params, last_step, "last_step", n_steps - 1);
   json_marshal::childFromJson(params, longest_valid_segment_length, "longest_valid_segment_length", 0.5);
@@ -1647,7 +1645,6 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value
   config = trajopt_common::TrajOptCollisionConfig(
       dist_pen, coeffs, contact_request_type, evaluator_type, longest_valid_segment_length);
   config.collision_margin_buffer = collision_margin_buffer;
-  config.use_weighted_sum = use_weighted_sum;
 
   // Check if data was set for individual pairs
   if (params.isMember("pairs"))
@@ -1687,7 +1684,6 @@ void CollisionTermInfo::fromJson(ProblemConstructionInfo& pci, const Json::Value
                                "first_step",
                                "last_step",
                                "evaluator_type",
-                               "use_weighted_sum",
                                "fixed_steps",
                                "contact_test_type",
                                "longest_valid_segment_length",
@@ -1717,21 +1713,15 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
         CollisionExpressionEvaluatorType expression_evaluator_type{};
         if (!current_fixed && !next_fixed)
         {
-          expression_evaluator_type = (config.use_weighted_sum) ?
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FREE_WEIGHTED_SUM :
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FREE;
+          expression_evaluator_type = CollisionExpressionEvaluatorType::START_FREE_END_FREE;
         }
         else if (current_fixed)
         {
-          expression_evaluator_type = (config.use_weighted_sum) ?
-                                          CollisionExpressionEvaluatorType::START_FIXED_END_FREE_WEIGHTED_SUM :
-                                          CollisionExpressionEvaluatorType::START_FIXED_END_FREE;
+          expression_evaluator_type = CollisionExpressionEvaluatorType::START_FIXED_END_FREE;
         }
         else if (next_fixed)
         {
-          expression_evaluator_type = (config.use_weighted_sum) ?
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FIXED_WEIGHTED_SUM :
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FIXED;
+          expression_evaluator_type = CollisionExpressionEvaluatorType::START_FREE_END_FIXED;
         }
         else
         {
@@ -1752,9 +1742,7 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
     }
     else
     {
-      CollisionExpressionEvaluatorType expression_evaluator_type =
-          (config.use_weighted_sum) ? CollisionExpressionEvaluatorType::SINGLE_TIME_STEP_WEIGHTED_SUM :
-                                      CollisionExpressionEvaluatorType::SINGLE_TIME_STEP;
+      CollisionExpressionEvaluatorType expression_evaluator_type = CollisionExpressionEvaluatorType::SINGLE_TIME_STEP;
       for (int i = first_step; i <= last_step; ++i)
       {
         if (std::find(fixed_steps.begin(), fixed_steps.end(), i) == fixed_steps.end())
@@ -1785,21 +1773,15 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
         CollisionExpressionEvaluatorType expression_evaluator_type{};
         if (!current_fixed && !next_fixed)
         {
-          expression_evaluator_type = (config.use_weighted_sum) ?
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FREE_WEIGHTED_SUM :
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FREE;
+          expression_evaluator_type = CollisionExpressionEvaluatorType::START_FREE_END_FREE;
         }
         else if (current_fixed)
         {
-          expression_evaluator_type = (config.use_weighted_sum) ?
-                                          CollisionExpressionEvaluatorType::START_FIXED_END_FREE_WEIGHTED_SUM :
-                                          CollisionExpressionEvaluatorType::START_FIXED_END_FREE;
+          expression_evaluator_type = CollisionExpressionEvaluatorType::START_FIXED_END_FREE;
         }
         else if (next_fixed)
         {
-          expression_evaluator_type = (config.use_weighted_sum) ?
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FIXED_WEIGHTED_SUM :
-                                          CollisionExpressionEvaluatorType::START_FREE_END_FIXED;
+          expression_evaluator_type = CollisionExpressionEvaluatorType::START_FREE_END_FIXED;
         }
         else
         {
@@ -1820,9 +1802,7 @@ void CollisionTermInfo::hatch(TrajOptProb& prob)
     }
     else
     {
-      CollisionExpressionEvaluatorType expression_evaluator_type =
-          (config.use_weighted_sum) ? CollisionExpressionEvaluatorType::SINGLE_TIME_STEP_WEIGHTED_SUM :
-                                      CollisionExpressionEvaluatorType::SINGLE_TIME_STEP;
+      CollisionExpressionEvaluatorType expression_evaluator_type = CollisionExpressionEvaluatorType::SINGLE_TIME_STEP;
       for (int i = first_step; i <= last_step; ++i)
       {
         if (std::find(fixed_steps.begin(), fixed_steps.end(), i) == fixed_steps.end())

--- a/trajopt_common/include/trajopt_common/collision_types.h
+++ b/trajopt_common/include/trajopt_common/collision_types.h
@@ -134,13 +134,6 @@ struct TrajOptCollisionConfig
    */
   int max_num_cnt{ 3 };
 
-  /**
-   * @brief Use the weighted sum for each link pair. This reduces the number equations added to the problem
-   * When enable it is good to start with a coefficient of 1 otherwise 20 is a good starting point.
-   * @note This is only used by trajopt and not trajopt_ifopt
-   */
-  bool use_weighted_sum{ false };
-
 protected:
   friend class boost::serialization::access;
   template <class Archive>

--- a/trajopt_common/src/collision_types.cpp
+++ b/trajopt_common/src/collision_types.cpp
@@ -93,7 +93,6 @@ void TrajOptCollisionConfig::serialize(Archive& ar, const unsigned int /*version
   ar& BOOST_SERIALIZATION_NVP(collision_coeff_data);
   ar& BOOST_SERIALIZATION_NVP(collision_margin_buffer);
   ar& BOOST_SERIALIZATION_NVP(max_num_cnt);
-  ar& BOOST_SERIALIZATION_NVP(use_weighted_sum);
 }
 
 double LinkMaxError::getMaxError() const


### PR DESCRIPTION
This PR removes the weighted sum collision methods from legacy `trajopt`. A number of issues were addressed with these methods during the implementation of `trajopt_ifopt` but they were never backported to legacy `trajopt`. Since the legacy `trajopt` will ultimately be sunset in favor of `trajopt_ifopt`, it doesn't make sense to go through the effort of backporting the fixes. Instead, we will remove them from legacy `trajopt` so users don't run into issues trying to use these methods that are known to have bugs.