### PR TITLE
Remove SafetyMarginData from fwd.h

### DIFF
--- a/trajopt_common/include/trajopt_common/fwd.h
+++ b/trajopt_common/include/trajopt_common/fwd.h
@@ -3,7 +3,6 @@
 
 namespace trajopt_common
 {
-struct SafetyMarginData;
 struct CollisionCoeffData;
 struct TrajOptCollisionConfig;
 struct LinkGradientResults;  // NOLINT


### PR DESCRIPTION
This struct was removed in a previous commit, but accidentally left in the forward declarations.