### PR TITLE
Fix bounds problem

### DIFF
--- a/trajopt_sco/src/optimizers.cpp
+++ b/trajopt_sco/src/optimizers.cpp
@@ -95,13 +95,13 @@ void BasicTrustRegionSQP::setTrustBoxConstraints(const DblVec& x)
   const VarVector& vars = prob_->getVars();
   assert(vars.size() == x.size());
   const DblVec& lb = prob_->getLowerBounds();
-  const DblVec ub = prob_->getUpperBounds();
+  const DblVec& ub = prob_->getUpperBounds();
   DblVec lbtrust(x.size());
   DblVec ubtrust(x.size());
   for (std::size_t i = 0; i < x.size(); ++i)
   {
-    lbtrust[i] = fmax(x[i] - param_.trust_box_size, lb[i]);
-    ubtrust[i] = fmin(x[i] + param_.trust_box_size, ub[i]);
+    lbtrust[i] = fmax(fmin(x[i], ub[i]) - param_.trust_box_size, lb[i]);
+    ubtrust[i] = fmin(fmax(x[i], lb[i]) + param_.trust_box_size, ub[i]);
   }
   model_->setVarBounds(vars, lbtrust, ubtrust);
 }


### PR DESCRIPTION
This fixes a problem with incorrect bounds. 

Example:
```
lb = -2.5
ub = 2.5
trust_box_size = 0.0015
x = 2.6
```

Then `lbtrust = 2.5985`, while `ubtrust = 2.5`, causing an error in OSQP, as the lower bound is larger than the upper bound.

With this PR, the resulting `lbtrust = 2.4985`, which is smaller than the upper bound.