### PR TITLE
Add required OSQP version to find_package

### DIFF
--- a/trajopt_ext/osqp/CMakeLists.txt
+++ b/trajopt_ext/osqp/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(ros_industrial_cmake_boilerplate REQUIRED)
 extract_package_metadata(pkg)
 project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX)
 
-find_package(osqp QUIET)
+find_package(osqp 0.6.3 QUIET)
 
 if(NOT ${osqp_FOUND} AND NOT TRAJOPT_OSQP_DISABLED)
   message(WARNING "No valid OSQP version found. Cloning OSQP 0.6.3 into build directory")


### PR DESCRIPTION
This [PR to tesseract_planning](https://github.com/tesseract-robotics/tesseract_planning/pull/661/files#diff-1add1246dba32ab02299a43b1d51c00a06e1faa8286ebb59346d2b6830dc289dR52) introduced an incompatibility with OSQP 0.6.2, the default on ROS Jazzy, as `linsys_solver_type::UNKNOWN_SOLVER` was introduced with 0.6.3.

With this PR 0.6.3 will be installed from source if 0.6.2 is available as system package, solving the problem.