### PR TITLE
Update conda CI to run on windows-2022

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   conda-win:
-    runs-on: windows-2019
+    runs-on: windows-2022
     defaults:
       run:
         shell: powershell
@@ -79,3 +79,4 @@ jobs:
         conda smithy regenerate
         
         conda mambabuild -m .ci_support/linux_64_.yaml --build-only .
+


### PR DESCRIPTION
As windows-2019 is unsupported now: https://github.com/actions/runner-images/issues/12045