### PR TITLE
Batch update the contact manager's object transforms

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -238,8 +238,10 @@ protected:
 
   std::pair<ContactResultMapConstPtr, ContactResultVectorConstPtr> GetContactResultCached(const DblVec& x);
 
-  static thread_local tesseract::common::TransformMap transforms_cache0;  // NOLINT
-  static thread_local tesseract::common::TransformMap transforms_cache1;  // NOLINT
+  static thread_local tesseract::common::TransformMap transforms_cache0;         // NOLINT
+  static thread_local tesseract::common::TransformMap transforms_cache1;         // NOLINT
+  static thread_local tesseract::common::TransformMap transforms_cache0_update;  // NOLINT
+  static thread_local tesseract::common::TransformMap transforms_cache1_update;  // NOLINT
 
   void CollisionsToDistanceExpressions(sco::AffExprVector& exprs,
                                        std::vector<double>& exprs_margin,

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -200,8 +200,10 @@ void DebugPrintInfo(const tesseract::collision::ContactResult& res,
 
 }  // namespace
 
-thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache0;  // NOLINT
-thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache1;  // NOLINT
+thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache0;         // NOLINT
+thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache1;         // NOLINT
+thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache0_update;  // NOLINT
+thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache1_update;  // NOLINT
 
 GradientResults CollisionEvaluator::GetGradient(const Eigen::VectorXd& dofvals,
                                                 const tesseract::collision::ContactResult& contact_result,
@@ -661,14 +663,17 @@ void SingleTimestepCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eig
                                                       tesseract::collision::ContactResultMap& dist_results)
 {
   transforms_cache0.clear();
+  transforms_cache0_update.clear();
   get_state_fn_(transforms_cache0, dof_vals);
 
   // If not empty then there are links that are not part of the kinematics object that can move (dynamic environment)
   for (const auto& link_name : diff_active_link_names_)
-    contact_manager_->setCollisionObjectsTransform(link_name, transforms_cache0[link_name]);
+    transforms_cache0_update[link_name] = transforms_cache0[link_name];
 
   for (const auto& link_name : manip_active_link_names_)
-    contact_manager_->setCollisionObjectsTransform(link_name, transforms_cache0[link_name]);
+    transforms_cache0_update[link_name] = transforms_cache0[link_name];
+
+  contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
 
   contact_manager_->contactTest(dist_results, collision_check_config_.contact_request);
 
@@ -835,13 +840,17 @@ void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Ve
   const double dist = (dof_vals1 - dof_vals0).norm();
 
   transforms_cache0.clear();
+  transforms_cache0_update.clear();
 
   // If not empty then there are links that are not part of the kinematics object that can move (dynamic environment)
   if (!diff_active_link_names_.empty())
   {
     get_state_fn_(transforms_cache0, dof_vals0);
+
     for (const auto& link_name : diff_active_link_names_)
-      contact_manager_->setCollisionObjectsTransform(link_name, transforms_cache0[link_name]);
+      transforms_cache0_update[link_name] = transforms_cache0[link_name];
+
+    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
   }
 
   long cnt = 2;
@@ -882,6 +891,10 @@ void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Ve
 #endif
   };
 
+  // Clear caches after diff block so inner loop only contains manip entries
+  transforms_cache0.clear();
+  transforms_cache0_update.clear();
+
   // Perform casted collision checking for sub trajectory and store results in contacts_vector
   const tesseract::common::TrajArray::Index last_state_idx{ subtraj.rows() - 1 };
   const double dt = 1.0 / double(last_state_idx);
@@ -892,7 +905,9 @@ void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Ve
     get_state_fn_(transforms_cache0, subtraj.row(i));
 
     for (const auto& link_name : manip_active_link_names_)
-      contact_manager_->setCollisionObjectsTransform(link_name, transforms_cache0[link_name]);
+      transforms_cache0_update[link_name] = transforms_cache0[link_name];
+
+    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
 
     contact_manager_->contactTest(contacts, collision_check_config_.contact_request);
 
@@ -1084,13 +1099,18 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
 
   transforms_cache0.clear();
   transforms_cache1.clear();
+  transforms_cache0_update.clear();
+  transforms_cache1_update.clear();
 
   // If not empty then there are links that are not part of the kinematics object that can move (dynamic environment)
   if (!diff_active_link_names_.empty())
   {
     get_state_fn_(transforms_cache0, dof_vals0);
+
     for (const auto& link_name : diff_active_link_names_)
-      contact_manager_->setCollisionObjectsTransform(link_name, transforms_cache0[link_name]);
+      transforms_cache0_update[link_name] = transforms_cache0[link_name];
+
+    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
   }
 
   // Define Filter
@@ -1119,6 +1139,12 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
 #endif
   };
 
+  // Clear caches after diff block so inner loops only contain manip entries
+  transforms_cache0.clear();
+  transforms_cache1.clear();
+  transforms_cache0_update.clear();
+  transforms_cache1_update.clear();
+
   if (dist > collision_check_config_.longest_valid_segment_length)
   {
     // Calculate the number state to interpolate
@@ -1140,8 +1166,12 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
       manip_->calcFwdKin(transforms_cache1, subtraj.row(i + 1));
 
       for (const auto& link_name : manip_active_link_names_)
-        contact_manager_->setCollisionObjectsTransform(
-            link_name, transforms_cache0[link_name], transforms_cache1[link_name]);
+      {
+        transforms_cache0_update[link_name] = transforms_cache0[link_name];
+        transforms_cache1_update[link_name] = transforms_cache1[link_name];
+      }
+
+      contact_manager_->setCollisionObjectsTransform(transforms_cache0_update, transforms_cache1_update);
 
       contact_manager_->contactTest(contacts, collision_check_config_.contact_request);
 
@@ -1157,9 +1187,14 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
   {
     manip_->calcFwdKin(transforms_cache0, dof_vals0);
     manip_->calcFwdKin(transforms_cache1, dof_vals1);
+
     for (const auto& link_name : manip_active_link_names_)
-      contact_manager_->setCollisionObjectsTransform(
-          link_name, transforms_cache0[link_name], transforms_cache1[link_name]);
+    {
+      transforms_cache0_update[link_name] = transforms_cache0[link_name];
+      transforms_cache1_update[link_name] = transforms_cache1[link_name];
+    }
+
+    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update, transforms_cache1_update);
 
     contact_manager_->contactTest(dist_results, collision_check_config_.contact_request);
 


### PR DESCRIPTION
This implements batch updating of the contact manager's object transforms. For Coal (and FCL, I expect) this is a measurable improvement, as otherwise each separate transform update will rebalance the broadphase AABB tree.

Once this is accepted, I'll PR the same for trajopt_ifopt.