### PR TITLE
Reduce allocation overhead and fix thread safety in collision evaluators

### DIFF
--- a/trajopt/include/trajopt/collision_terms.hpp
+++ b/trajopt/include/trajopt/collision_terms.hpp
@@ -238,10 +238,11 @@ protected:
 
   std::pair<ContactResultMapConstPtr, ContactResultVectorConstPtr> GetContactResultCached(const DblVec& x);
 
-  static thread_local tesseract::common::TransformMap transforms_cache0;         // NOLINT
-  static thread_local tesseract::common::TransformMap transforms_cache1;         // NOLINT
-  static thread_local tesseract::common::TransformMap transforms_cache0_update;  // NOLINT
-  static thread_local tesseract::common::TransformMap transforms_cache1_update;  // NOLINT
+  tesseract::common::TransformMap transforms_cache0_;
+  tesseract::common::TransformMap transforms_cache1_;
+  tesseract::common::TransformMap transforms_diff_update_;
+  tesseract::common::TransformMap transforms_cache0_update_;
+  tesseract::common::TransformMap transforms_cache1_update_;
 
   void CollisionsToDistanceExpressions(sco::AffExprVector& exprs,
                                        std::vector<double>& exprs_margin,

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -481,7 +481,7 @@ void CollisionEvaluator::CalcDistExpressionsStartFree(const DblVec& x,
   for (std::size_t i = 0; i < exprs0.size(); ++i)
   {
     exprs[i] = sco::AffExpr(dist_results[i].get().distance);
-    sco::exprInc(exprs[i], exprs0[i]);
+    sco::exprInc(exprs[i], std::move(exprs0[i]));
     exprs[i] = sco::cleanupAff(exprs[i]);
   }
 }
@@ -502,7 +502,7 @@ void CollisionEvaluator::CalcDistExpressionsEndFree(const DblVec& x,
   for (std::size_t i = 0; i < exprs1.size(); ++i)
   {
     exprs[i] = sco::AffExpr(dist_results[i].get().distance);
-    sco::exprInc(exprs[i], exprs1[i]);
+    sco::exprInc(exprs[i], std::move(exprs1[i]));
     exprs[i] = sco::cleanupAff(exprs[i]);
   }
 }
@@ -531,8 +531,8 @@ void CollisionEvaluator::CalcDistExpressionsBothFree(const DblVec& x,
   for (std::size_t i = 0; i < exprs0.size(); ++i)
   {
     exprs[i] = sco::AffExpr(dist_results[i].get().distance);
-    sco::exprInc(exprs[i], exprs0[i]);
-    sco::exprInc(exprs[i], exprs1[i]);
+    sco::exprInc(exprs[i], std::move(exprs0[i]));
+    sco::exprInc(exprs[i], std::move(exprs1[i]));
     exprs[i] = sco::cleanupAff(exprs[i]);
   }
 }

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -390,7 +390,9 @@ void CollisionEvaluator::CollisionsToDistanceExpressions(sco::AffExprVector& exp
 CollisionEvaluator::CollisionEvaluator(tesseract::kinematics::JointGroup::ConstPtr manip,
                                        tesseract::environment::Environment::ConstPtr env,
                                        bool dynamic_environment)
-  : manip_(std::move(manip)), env_(std::move(env)), dynamic_environment_(dynamic_environment)
+  : manip_(std::make_shared<tesseract::kinematics::JointGroup>(*manip))
+  , env_(std::move(env))
+  , dynamic_environment_(dynamic_environment)
 {
   manip_active_link_names_ = manip_->getActiveLinkNames();
 

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -200,11 +200,6 @@ void DebugPrintInfo(const tesseract::collision::ContactResult& res,
 
 }  // namespace
 
-thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache0;         // NOLINT
-thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache1;         // NOLINT
-thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache0_update;  // NOLINT
-thread_local tesseract::common::TransformMap CollisionEvaluator::transforms_cache1_update;  // NOLINT
-
 GradientResults CollisionEvaluator::GetGradient(const Eigen::VectorXd& dofvals,
                                                 const tesseract::collision::ContactResult& contact_result,
                                                 double margin,
@@ -660,18 +655,16 @@ void SingleTimestepCollisionEvaluator::CalcCollisions(const DblVec& x,
 void SingleTimestepCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::VectorXd>& dof_vals,
                                                       tesseract::collision::ContactResultMap& dist_results)
 {
-  transforms_cache0.clear();
-  transforms_cache0_update.clear();
-  get_state_fn_(transforms_cache0, dof_vals);
+  get_state_fn_(transforms_cache0_, dof_vals);
 
   // If not empty then there are links that are not part of the kinematics object that can move (dynamic environment)
   for (const auto& link_name : diff_active_link_names_)
-    transforms_cache0_update[link_name] = transforms_cache0[link_name];
+    transforms_cache0_update_[link_name] = transforms_cache0_[link_name];
 
   for (const auto& link_name : manip_active_link_names_)
-    transforms_cache0_update[link_name] = transforms_cache0[link_name];
+    transforms_cache0_update_[link_name] = transforms_cache0_[link_name];
 
-  contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
+  contact_manager_->setCollisionObjectsTransform(transforms_cache0_update_);
 
   contact_manager_->contactTest(dist_results, collision_check_config_.contact_request);
 
@@ -837,18 +830,15 @@ void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Ve
   // the longest valid segment length.
   const double dist = (dof_vals1 - dof_vals0).norm();
 
-  transforms_cache0.clear();
-  transforms_cache0_update.clear();
-
   // If not empty then there are links that are not part of the kinematics object that can move (dynamic environment)
   if (!diff_active_link_names_.empty())
   {
-    get_state_fn_(transforms_cache0, dof_vals0);
+    get_state_fn_(transforms_cache0_, dof_vals0);
 
     for (const auto& link_name : diff_active_link_names_)
-      transforms_cache0_update[link_name] = transforms_cache0[link_name];
+      transforms_diff_update_[link_name] = transforms_cache0_[link_name];
 
-    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
+    contact_manager_->setCollisionObjectsTransform(transforms_diff_update_);
   }
 
   long cnt = 2;
@@ -889,10 +879,6 @@ void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Ve
 #endif
   };
 
-  // Clear caches after diff block so inner loop only contains manip entries
-  transforms_cache0.clear();
-  transforms_cache0_update.clear();
-
   // Perform casted collision checking for sub trajectory and store results in contacts_vector
   const tesseract::common::TrajArray::Index last_state_idx{ subtraj.rows() - 1 };
   const double dt = 1.0 / double(last_state_idx);
@@ -900,12 +886,12 @@ void DiscreteCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Ve
   tesseract::collision::ContactResultMap contacts{ dist_results };
   for (int i = 0; i < subtraj.rows(); ++i)
   {
-    get_state_fn_(transforms_cache0, subtraj.row(i));
+    get_state_fn_(transforms_cache0_, subtraj.row(i));
 
     for (const auto& link_name : manip_active_link_names_)
-      transforms_cache0_update[link_name] = transforms_cache0[link_name];
+      transforms_cache0_update_[link_name] = transforms_cache0_[link_name];
 
-    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
+    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update_);
 
     contact_manager_->contactTest(contacts, collision_check_config_.contact_request);
 
@@ -935,11 +921,8 @@ void DiscreteCollisionEvaluator::Plot(const std::shared_ptr<tesseract::visualiza
   const Eigen::VectorXd dofvals0 = sco::getVec(x, vars0_);
   const Eigen::VectorXd dofvals1 = sco::getVec(x, vars1_);
 
-  transforms_cache0.clear();
-  transforms_cache1.clear();
-
-  manip_->calcFwdKin(transforms_cache0, dofvals0);
-  manip_->calcFwdKin(transforms_cache1, dofvals1);
+  manip_->calcFwdKin(transforms_cache0_, dofvals0);
+  manip_->calcFwdKin(transforms_cache1_, dofvals1);
 
   tesseract::collision::ContactResultVector dist_results_copy(dist_results.size());
   Eigen::VectorXd collision_margins(dist_results.size());
@@ -1095,20 +1078,15 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
   // the longest valid segment length.
   const double dist = (dof_vals1 - dof_vals0).norm();
 
-  transforms_cache0.clear();
-  transforms_cache1.clear();
-  transforms_cache0_update.clear();
-  transforms_cache1_update.clear();
-
   // If not empty then there are links that are not part of the kinematics object that can move (dynamic environment)
   if (!diff_active_link_names_.empty())
   {
-    get_state_fn_(transforms_cache0, dof_vals0);
+    get_state_fn_(transforms_cache0_, dof_vals0);
 
     for (const auto& link_name : diff_active_link_names_)
-      transforms_cache0_update[link_name] = transforms_cache0[link_name];
+      transforms_diff_update_[link_name] = transforms_cache0_[link_name];
 
-    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update);
+    contact_manager_->setCollisionObjectsTransform(transforms_diff_update_);
   }
 
   // Define Filter
@@ -1137,12 +1115,6 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
 #endif
   };
 
-  // Clear caches after diff block so inner loops only contain manip entries
-  transforms_cache0.clear();
-  transforms_cache1.clear();
-  transforms_cache0_update.clear();
-  transforms_cache1_update.clear();
-
   if (dist > collision_check_config_.longest_valid_segment_length)
   {
     // Calculate the number state to interpolate
@@ -1160,16 +1132,16 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
     const double dt = 1.0 / double(last_state_idx);
     for (int i = 0; i < subtraj.rows() - 1; ++i)
     {
-      manip_->calcFwdKin(transforms_cache0, subtraj.row(i));
-      manip_->calcFwdKin(transforms_cache1, subtraj.row(i + 1));
+      manip_->calcFwdKin(transforms_cache0_, subtraj.row(i));
+      manip_->calcFwdKin(transforms_cache1_, subtraj.row(i + 1));
 
       for (const auto& link_name : manip_active_link_names_)
       {
-        transforms_cache0_update[link_name] = transforms_cache0[link_name];
-        transforms_cache1_update[link_name] = transforms_cache1[link_name];
+        transforms_cache0_update_[link_name] = transforms_cache0_[link_name];
+        transforms_cache1_update_[link_name] = transforms_cache1_[link_name];
       }
 
-      contact_manager_->setCollisionObjectsTransform(transforms_cache0_update, transforms_cache1_update);
+      contact_manager_->setCollisionObjectsTransform(transforms_cache0_update_, transforms_cache1_update_);
 
       contact_manager_->contactTest(contacts, collision_check_config_.contact_request);
 
@@ -1183,16 +1155,16 @@ void CastCollisionEvaluator::CalcCollisions(const Eigen::Ref<const Eigen::Vector
   }
   else
   {
-    manip_->calcFwdKin(transforms_cache0, dof_vals0);
-    manip_->calcFwdKin(transforms_cache1, dof_vals1);
+    manip_->calcFwdKin(transforms_cache0_, dof_vals0);
+    manip_->calcFwdKin(transforms_cache1_, dof_vals1);
 
     for (const auto& link_name : manip_active_link_names_)
     {
-      transforms_cache0_update[link_name] = transforms_cache0[link_name];
-      transforms_cache1_update[link_name] = transforms_cache1[link_name];
+      transforms_cache0_update_[link_name] = transforms_cache0_[link_name];
+      transforms_cache1_update_[link_name] = transforms_cache1_[link_name];
     }
 
-    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update, transforms_cache1_update);
+    contact_manager_->setCollisionObjectsTransform(transforms_cache0_update_, transforms_cache1_update_);
 
     contact_manager_->contactTest(dist_results, collision_check_config_.contact_request);
 

--- a/trajopt/src/collision_terms.cpp
+++ b/trajopt/src/collision_terms.cpp
@@ -455,17 +455,13 @@ CollisionEvaluator::GetContactResultCached(const DblVec& x)
 
   LOG_DEBUG("not using cached collision check\n")
 
-  /**
-   * We tried different combinations of how to store the dist_map and also passing in a sub_dist_map to CalcCollisions,
-   * using member variable and thread_local. Just making the dist_map thread_local and making a copy for sub_dist_result
-   * in CalcCollisions had the most significant impact on peformance and memory.
-   */
-  TRAJOPT_THREAD_LOCAL tesseract::collision::ContactResultMap dist_map;
-  dist_map.clear();
+  // A per-call local moved into make_shared avoids the deep copy that the
+  // previous thread_local approach required on every cache miss.
+  tesseract::collision::ContactResultMap dist_map;
 
   CalcCollisions(x, dist_map);
 
-  auto dist_map_ptr = std::make_shared<tesseract::collision::ContactResultMap>(dist_map);
+  auto dist_map_ptr = std::make_shared<tesseract::collision::ContactResultMap>(std::move(dist_map));
   auto dist_vec_ptr = std::make_shared<ContactResultVectorWrapper>();
   dist_map_ptr->flattenWrapperResults(*dist_vec_ptr);
 

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -120,7 +120,6 @@ DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
 
 VectorXd DynamicCartPoseErrCalculator::operator()(const VectorXd& dof_vals) const
 {
-  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -176,7 +175,6 @@ DynamicCartPoseJacCalculator::DynamicCartPoseJacCalculator(
 MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
 {
   // Duplicated from calcForwardNumJac in trajopt_sco/src/num_diff.cpp, but with ignoring tolerances
-  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -278,7 +276,6 @@ CartPoseErrCalculator::CartPoseErrCalculator(
 
 VectorXd CartPoseErrCalculator::operator()(const VectorXd& dof_vals) const
 {
-  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -371,7 +368,6 @@ CartPoseJacCalculator::CartPoseJacCalculator(
 
 MatrixXd CartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
 {
-  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -435,8 +431,6 @@ CartVelErrCalculator::CartVelErrCalculator(std::shared_ptr<const tesseract::kine
 VectorXd CartVelErrCalculator::operator()(const VectorXd& dof_vals) const
 {
   auto n_dof = static_cast<int>(manip_->numJoints());
-
-  transforms_cache.clear();
 
   manip_->calcFwdKin(transforms_cache, dof_vals.topRows(n_dof));
   Isometry3d pose0 = transforms_cache[link_] * tcp_;

--- a/trajopt_sco/include/trajopt_sco/expr_ops.hpp
+++ b/trajopt_sco/include/trajopt_sco/expr_ops.hpp
@@ -27,10 +27,18 @@ inline void exprInc(AffExpr& a, const AffExpr& b)
   a.coeffs.insert(a.coeffs.end(), b.coeffs.begin(), b.coeffs.end());
   a.vars.insert(a.vars.end(), b.vars.begin(), b.vars.end());
 }
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): members are moved via make_move_iterator
+inline void exprInc(AffExpr& a, AffExpr&& b)
+{
+  a.constant += b.constant;
+  a.coeffs.insert(a.coeffs.end(), std::make_move_iterator(b.coeffs.begin()), std::make_move_iterator(b.coeffs.end()));
+  a.vars.insert(a.vars.end(), std::make_move_iterator(b.vars.begin()), std::make_move_iterator(b.vars.end()));
+}
 inline void exprInc(AffExpr& a, const Var& b) { exprInc(a, AffExpr(b)); }
 inline void exprInc(QuadExpr& a, double b) { exprInc(a.affexpr, b); }
 inline void exprInc(QuadExpr& a, const Var& b) { exprInc(a.affexpr, AffExpr(b)); }
 inline void exprInc(QuadExpr& a, const AffExpr& b) { exprInc(a.affexpr, b); }
+inline void exprInc(QuadExpr& a, AffExpr&& b) { exprInc(a.affexpr, std::move(b)); }
 inline void exprInc(QuadExpr& a, const QuadExpr& b)
 {
   exprInc(a.affexpr, b.affexpr);
@@ -38,22 +46,31 @@ inline void exprInc(QuadExpr& a, const QuadExpr& b)
   a.vars1.insert(a.vars1.end(), b.vars1.begin(), b.vars1.end());
   a.vars2.insert(a.vars2.end(), b.vars2.begin(), b.vars2.end());
 }
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): members are moved via make_move_iterator
+inline void exprInc(QuadExpr& a, QuadExpr&& b)
+{
+  exprInc(a.affexpr, std::move(b.affexpr));
+  a.coeffs.insert(a.coeffs.end(), std::make_move_iterator(b.coeffs.begin()), std::make_move_iterator(b.coeffs.end()));
+  a.vars1.insert(a.vars1.end(), std::make_move_iterator(b.vars1.begin()), std::make_move_iterator(b.vars1.end()));
+  a.vars2.insert(a.vars2.end(), std::make_move_iterator(b.vars2.begin()), std::make_move_iterator(b.vars2.end()));
+}
 
 // subtraction
 inline void exprDec(AffExpr& a, double b) { a.constant -= b; }
 inline void exprDec(AffExpr& a, AffExpr b)
 {
   exprScale(b, -1);
-  exprInc(a, b);
+  exprInc(a, std::move(b));
 }
 inline void exprDec(AffExpr& a, const Var& b) { exprDec(a, AffExpr(b)); }
 inline void exprDec(QuadExpr& a, double b) { exprDec(a.affexpr, b); }
 inline void exprDec(QuadExpr& a, const Var& b) { exprDec(a.affexpr, b); }
 inline void exprDec(QuadExpr& a, const AffExpr& b) { exprDec(a.affexpr, b); }
+inline void exprDec(QuadExpr& a, AffExpr&& b) { exprDec(a.affexpr, std::move(b)); }
 inline void exprDec(QuadExpr& a, QuadExpr b)
 {
   exprScale(b, -1);
-  exprInc(a, b);
+  exprInc(a, std::move(b));
 }
 
 /////////////////////


### PR DESCRIPTION
(Disclosure: Created with help of Claude.)

  - Clone JointGroup per CollisionEvaluator (759ebbc6) — Each evaluator now owns a cloned JointGroup instead of sharing one. This eliminates mutex contention in calculateTransforms under OMP concurrency, and fixes a latent data race where calcJacobianHelper calls JntToJac — which mutates KDL's internal Joint::posecaching state — without holding the mutex. Perf: lll_lock_wait 0.29→0.13%, KDL::Joint::pose 0.70→0.31%.
  - Move ContactResultMap instead of deep copying (53544b2a) — Replace the thread_local + clear() + deep copy pattern in GetContactResultCached with a per-call local moved into make_shared. The previous approach copied every Rb_tree node, string key, and ContactResult vector on every cache miss. Perf:_Rb_tree::_M_copy (0.46%) and _M_erase (0.43%) eliminated entirely, memmove -0.35%, allocator group -0.29%. Total ~1.5%.
  - Use persistent FK transform caches (41bb694f) — Convert the static thread_local TransformMap caches to instance members and stop clearing them before each FK call. operator[] overwrites existing entries in-place, so clearing only adds deallocation and reallocation overhead. Adds transforms_diff_update_ to separate diff-block and manip-block entries, avoiding the need to clear between phases. Perf: TransformMap::clear() (0.90%) and _M_insert_unique_node (0.14%) eliminated, but operator[] increased from 1.56→2.25% (+0.69%) because hash lookups on pre-populated maps are more expensive than inserts into empty ones. Net ~0.5%.
  - Add rvalue overloads for exprInc/exprDec (4d03f60f) — exprInc(AffExpr&, const AffExpr&) copies the vars vector, bumping atomic refcounts on every shared_ptr<VarRep>. The new rvalue overloads use make_move_iterator to transfer elements instead. Also adds std::move at call sites in CalcDistExpressions*Free where local vectors were passed as lvalues despite being discarded immediately after. Perf: _M_range_insert -0.12%, _Sp_counted_base::_M_release -0.09%. Total ~0.25%.

  Related: tesseract state_solver fix

  The persistent FK caches above rely on the state solver overwriting existing TransformMap entries rather than skipping them. The KDL solver already does this via operator[], but the OFKT solver used insert() which silently skips existing keys. This was fixed separately in tesseract (https://github.com/tesseract-robotics/tesseract/pull/1271), with a corresponding removal of redundant TransformMap::clear() calls in kinematic_terms.cpp (b87a1711). Perf: TransformMap::clear() 1.38→0.99% (-0.39%), but operator[] 1.72→1.97% (+0.25%) for the same reason as above. Net ~0.17%.

  Profiling

  Measured on a private planning setup (cast collision, large kinematic tree, OMP concurrency) using perf. Each optimization was applied incrementally and profiled in isolation against the preceding baseline.

  The net picture is that eliminating allocation-heavy patterns (clear/rebuild, deep copy) shifts cost toward hash lookups on pre-populated maps. The savings outweigh the added lookup cost, but the margin is smaller than the headline numbers suggest: e.g. the FK cache optimization eliminates 1.04% but adds back 0.69% in operator[], for a net of ~0.5%.

  Overall: ~5% wall-clock reduction, with 2.4% of CPU symbols eliminated entirely, offset by ~0.7% increased operator[] cost and measurement noise in other symbols. The JointGroup clone (mutex + correctness) and ContactResultMap move (deep copy elimination) are the largest clear wins.

  Profiling

  Measured on a private planning setup (cast collision, large kinematic tree, OMP concurrency) using perf. Each optimization was applied incrementally and profiled in isolation against the preceding baseline. Overall: ~5% wall-clock reduction, with 2.4% of CPU symbols eliminated entirely, 1.7% significantly reduced, and 0.4% less allocator overhead.