### PR TITLE
Fix toleranced Cartesian waypoints

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -24,5 +24,5 @@ jobs:
           ./.run-clang-format
           if [ $? -ge 1 ]; then return 1; fi
           output=$(git diff)
-          echo $output
+          echo "$output"
           if [ -n "$output" ]; then exit 1; else exit 0; fi

--- a/ci.diff
+++ b/ci.diff
@@ -1,0 +1,49 @@
+diff --git a/trajopt/src/kinematic_terms.cpp b/trajopt/src/kinematic_terms.cpp
+index 0834c40..dd20e24 100644
+--- a/trajopt/src/kinematic_terms.cpp
++++ b/trajopt/src/kinematic_terms.cpp
+@@ -49,8 +49,8 @@ void validateTolerances(const char* who, const Eigen::VectorXd& lower, const Eig
+   if (lower.size() != 0 && (lower.array() > upper.array()).any())
+   {
+     std::stringstream ss;
+-    ss << who << ": Inverted tolerance band — lower > upper at one or more indices. lower: ["
+-       << lower.transpose() << "], upper: [" << upper.transpose() << "]";
++    ss << who << ": Inverted tolerance band — lower > upper at one or more indices. lower: [" << lower.transpose()
++       << "], upper: [" << upper.transpose() << "]";
+     throw std::runtime_error(ss.str());
+   }
+ }
+diff --git a/trajopt/test/kinematic_costs_unit.cpp b/trajopt/test/kinematic_costs_unit.cpp
+index de04096..a9cdb5e 100644
+--- a/trajopt/test/kinematic_costs_unit.cpp
++++ b/trajopt/test/kinematic_costs_unit.cpp
+@@ -392,19 +392,17 @@ TEST_F(KinematicCostsTest, CartPoseCalculators_InvertedToleranceBandThrows)  //
+   lower << 0.0, 0.0, 0.0, 0.5, 0.0, 0.0;   // rx lower = 0.5
+   upper << 0.0, 0.0, 0.0, -0.5, 0.0, 0.0;  // rx upper = -0.5  → inverted
+ 
+-  EXPECT_THROW(
+-      CartPoseErrCalculator(kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower,
+-                            upper),
+-      std::runtime_error);
+-  EXPECT_THROW(
+-      CartPoseJacCalculator(kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower,
+-                            upper),
+-      std::runtime_error);
+-  EXPECT_THROW(DynamicCartPoseErrCalculator(kin, source_frame, target_frame, source_frame_offset, target_frame_offset,
+-                                            indices, lower, upper),
++  EXPECT_THROW(CartPoseErrCalculator(
++                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
+                std::runtime_error);
+-  EXPECT_THROW(DynamicCartPoseJacCalculator(kin, source_frame, target_frame, source_frame_offset, target_frame_offset,
+-                                            indices, lower, upper),
++  EXPECT_THROW(CartPoseJacCalculator(
++                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
++               std::runtime_error);
++  EXPECT_THROW(DynamicCartPoseErrCalculator(
++                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
++               std::runtime_error);
++  EXPECT_THROW(DynamicCartPoseJacCalculator(
++                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
+                std::runtime_error);
+ }
+ 

--- a/trajopt/include/trajopt/kinematic_terms.hpp
+++ b/trajopt/include/trajopt/kinematic_terms.hpp
@@ -101,13 +101,20 @@ struct DynamicCartPoseJacCalculator : TrajOptMatrixOfVector
   /** @brief perturbation amount for calculating Jacobian */
   double epsilon_;
 
+  /** @brief Optional per-component tolerance band, forwarded to calcJacobianTransformErrorDiff so the FD jacobian
+   * agrees with the toleranced error inside the band. Empty means no tolerances applied. */
+  Eigen::VectorXd lower_tolerance_;
+  Eigen::VectorXd upper_tolerance_;
+
   DynamicCartPoseJacCalculator(
       std::shared_ptr<const tesseract::kinematics::JointGroup> manip,
       std::string source_frame,
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      const Eigen::VectorXi& indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()));
+      const Eigen::VectorXi& indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
+      const Eigen::VectorXd& lower_tolerance = {},
+      const Eigen::VectorXd& upper_tolerance = {});
 
   Eigen::MatrixXd operator()(const Eigen::VectorXd& dof_vals) const override;
 };
@@ -200,13 +207,20 @@ struct CartPoseJacCalculator : TrajOptMatrixOfVector
   /** @brief perturbation amount for calculating Jacobian */
   double epsilon_;
 
+  /** @brief Optional per-component tolerance band, forwarded to calcJacobianTransformErrorDiff. Empty means no
+   * tolerances applied. */
+  Eigen::VectorXd lower_tolerance_;
+  Eigen::VectorXd upper_tolerance_;
+
   CartPoseJacCalculator(
       std::shared_ptr<const tesseract::kinematics::JointGroup> manip,
       std::string source_frame,
       std::string target_frame,
       const Eigen::Isometry3d& source_frame_offset = Eigen::Isometry3d::Identity(),
       const Eigen::Isometry3d& target_frame_offset = Eigen::Isometry3d::Identity(),
-      const Eigen::VectorXi& indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()));
+      const Eigen::VectorXi& indices = Eigen::Matrix<int, 1, 6>(std::vector<int>({ 0, 1, 2, 3, 4, 5 }).data()),
+      const Eigen::VectorXd& lower_tolerance = {},
+      const Eigen::VectorXd& upper_tolerance = {});
 
   Eigen::MatrixXd operator()(const Eigen::VectorXd& dof_vals) const override;
 };

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -5,6 +5,7 @@ TRAJOPT_IGNORE_WARNINGS_PUSH
 #include <boost/format.hpp>
 #include <iostream>
 #include <tesseract/common/eigen_types.h>
+#include <tesseract/common/utils.h>
 #include <tesseract/kinematics/joint_group.h>
 #include <tesseract/kinematics/utils.h>
 #include <tesseract/scene_graph/link.h>
@@ -33,44 +34,6 @@ using Eigen::VectorXd;
 
 namespace trajopt
 {
-// Function to apply tolerances to error values
-Eigen::VectorXd applyTolerances(const Eigen::VectorXd& error,
-                                const Eigen::VectorXd& lower_tolerance,
-                                const Eigen::VectorXd& upper_tolerance)
-{
-  Eigen::VectorXd resultant(error.size());
-
-  if (error.size() > lower_tolerance.size() || error.size() > upper_tolerance.size())
-  {
-    std::stringstream error_ss;
-    error_ss << "applyTolerances: error vector size greater than tolerance vector size: ";
-    error_ss << lower_tolerance.size() << ", upper: " << upper_tolerance.size() << ", error: " << error.size();
-    throw std::runtime_error(error_ss.str());
-  }
-
-  // Iterate through each element
-  for (int i = 0; i < error.size(); ++i)
-  {
-    // If error is within tolerances, set resultant to 0
-    if (error(i) >= lower_tolerance(i) && error(i) <= upper_tolerance(i))
-    {
-      resultant(i) = 0.0;
-    }
-    // If error is below lower tolerance, set resultant to error - lower_tolerance
-    else if (error(i) < lower_tolerance(i))
-    {
-      resultant(i) = error(i) - lower_tolerance(i);
-    }
-    // If error is above upper tolerance, set resultant to error - upper_tolerance
-    else if (error(i) > upper_tolerance(i))
-    {
-      resultant(i) = error(i) - upper_tolerance(i);
-    }
-  }
-
-  return resultant;
-}
-
 DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
     std::shared_ptr<const tesseract::kinematics::JointGroup> manip,
     std::string source_frame,
@@ -92,7 +55,7 @@ DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
   if (lower_tolerance.size() != upper_tolerance.size())
   {
     std::stringstream error_ss;
-    error_ss << "CartPoseErrCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance.size()
+    error_ss << "DynamicCartPoseErrCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance.size()
              << ", upper: " << upper_tolerance.size();
     throw std::runtime_error(error_ss.str());
   }
@@ -109,11 +72,9 @@ DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
   {
     error_function = [lower_tolerance, upper_tolerance](const Eigen::Isometry3d& target_tf,
                                                         const Eigen::Isometry3d& source_tf) -> Eigen::VectorXd {
-      // Calculate the error using tesseract::common::calcTransformError or equivalent
-      const VectorXd err = tesseract::common::calcTransformError(target_tf, source_tf);
-
-      // Apply tolerances
-      return applyTolerances(err, lower_tolerance, upper_tolerance);
+      VectorXd err = tesseract::common::calcTransformError(target_tf, source_tf);
+      tesseract::common::applyTolerances(err, lower_tolerance, upper_tolerance);
+      return err;
     };
   }
 }
@@ -160,7 +121,9 @@ DynamicCartPoseJacCalculator::DynamicCartPoseJacCalculator(
     std::string target_frame,
     const Eigen::Isometry3d& source_frame_offset,  // NOLINT(modernize-pass-by-value)
     const Eigen::Isometry3d& target_frame_offset,  // NOLINT(modernize-pass-by-value)
-    const Eigen::VectorXi& indices)                // NOLINT(modernize-pass-by-value)
+    const Eigen::VectorXi& indices,                // NOLINT(modernize-pass-by-value)
+    const Eigen::VectorXd& lower_tolerance,        // NOLINT(modernize-pass-by-value)
+    const Eigen::VectorXd& upper_tolerance)        // NOLINT(modernize-pass-by-value)
   : manip_(std::move(manip))
   , source_frame_(std::move(source_frame))
   , source_frame_offset_(source_frame_offset)
@@ -168,13 +131,23 @@ DynamicCartPoseJacCalculator::DynamicCartPoseJacCalculator(
   , target_frame_offset_(target_frame_offset)
   , indices_(indices)
   , epsilon_(DEFAULT_EPSILON)
+  , lower_tolerance_(lower_tolerance)
+  , upper_tolerance_(upper_tolerance)
 {
   assert(indices_.size() <= 6);
+
+  if (lower_tolerance_.size() != upper_tolerance_.size())
+  {
+    std::stringstream error_ss;
+    error_ss << "DynamicCartPoseJacCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance_.size()
+             << ", upper: " << upper_tolerance_.size();
+    throw std::runtime_error(error_ss.str());
+  }
 }
 
 MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
 {
-  // Duplicated from calcForwardNumJac in trajopt_sco/src/num_diff.cpp, but with ignoring tolerances
+  // Finite-difference jacobian of the (optionally toleranced) Cartesian error.
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -187,8 +160,8 @@ MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) cons
     manip_->calcFwdKin(transforms_cache, dof_vals_pert);
     const Isometry3d source_tf_pert = transforms_cache[source_frame_] * source_frame_offset_;
     const Isometry3d target_tf_pert = transforms_cache[target_frame_] * target_frame_offset_;
-    VectorXd error_diff =
-        tesseract::common::calcJacobianTransformErrorDiff(target_tf, target_tf_pert, source_tf, source_tf_pert);
+    VectorXd error_diff = tesseract::common::calcJacobianTransformErrorDiff(
+        target_tf, target_tf_pert, source_tf, source_tf_pert, lower_tolerance_, upper_tolerance_);
 
     VectorXd reduced_error_diff(indices_.size());
     for (int i = 0; i < indices_.size(); ++i)
@@ -253,22 +226,18 @@ CartPoseErrCalculator::CartPoseErrCalculator(
     {
       error_function_ = [lower_tolerance, upper_tolerance](const Eigen::Isometry3d& target_tf,
                                                            const Eigen::Isometry3d& source_tf) -> Eigen::VectorXd {
-        // Calculate the error using tesseract::common::calcTransformError or equivalent
-        const VectorXd err = tesseract::common::calcTransformError(source_tf, target_tf);
-
-        // Apply tolerances
-        return applyTolerances(err, lower_tolerance, upper_tolerance);
+        VectorXd err = tesseract::common::calcTransformError(source_tf, target_tf);
+        tesseract::common::applyTolerances(err, lower_tolerance, upper_tolerance);
+        return err;
       };
     }
     else
     {
       error_function_ = [lower_tolerance, upper_tolerance](const Eigen::Isometry3d& target_tf,
                                                            const Eigen::Isometry3d& source_tf) -> Eigen::VectorXd {
-        // Calculate the error using tesseract::common::calcTransformError or equivalent
-        const VectorXd err = tesseract::common::calcTransformError(target_tf, source_tf);
-
-        // Apply tolerances
-        return applyTolerances(err, lower_tolerance, upper_tolerance);
+        VectorXd err = tesseract::common::calcTransformError(target_tf, source_tf);
+        tesseract::common::applyTolerances(err, lower_tolerance, upper_tolerance);
+        return err;
       };
     }
   }
@@ -316,7 +285,9 @@ CartPoseJacCalculator::CartPoseJacCalculator(
     std::string target_frame,
     const Eigen::Isometry3d& source_frame_offset,  // NOLINT(modernize-pass-by-value)
     const Eigen::Isometry3d& target_frame_offset,  // NOLINT(modernize-pass-by-value)
-    const Eigen::VectorXi& indices)                // NOLINT(modernize-pass-by-value)
+    const Eigen::VectorXi& indices,                // NOLINT(modernize-pass-by-value)
+    const Eigen::VectorXd& lower_tolerance,        // NOLINT(modernize-pass-by-value)
+    const Eigen::VectorXd& upper_tolerance)        // NOLINT(modernize-pass-by-value)
   : manip_(std::move(manip))
   , source_frame_(std::move(source_frame))
   , source_frame_offset_(source_frame_offset)
@@ -325,8 +296,18 @@ CartPoseJacCalculator::CartPoseJacCalculator(
   , is_target_active_(manip_->isActiveLinkName(target_frame_))
   , indices_(indices)
   , epsilon_(DEFAULT_EPSILON)
+  , lower_tolerance_(lower_tolerance)
+  , upper_tolerance_(upper_tolerance)
 {
   assert(indices_.size() <= 6);
+
+  if (lower_tolerance_.size() != upper_tolerance_.size())
+  {
+    std::stringstream error_ss;
+    error_ss << "CartPoseJacCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance_.size()
+             << ", upper: " << upper_tolerance_.size();
+    throw std::runtime_error(error_ss.str());
+  }
 
   if (is_target_active_)
   {
@@ -336,8 +317,8 @@ CartPoseJacCalculator::CartPoseJacCalculator(
                                   tesseract::common::TransformMap& state_cache) -> VectorXd {
       manip_->calcFwdKin(state_cache, vals);
       const Isometry3d perturbed_target_tf = state_cache[target_frame_] * target_frame_offset_;
-      VectorXd error_diff =
-          tesseract::common::calcJacobianTransformErrorDiff(source_tf, target_tf, perturbed_target_tf);
+      VectorXd error_diff = tesseract::common::calcJacobianTransformErrorDiff(
+          source_tf, target_tf, perturbed_target_tf, lower_tolerance_, upper_tolerance_);
 
       VectorXd reduced_error_diff(indices_.size());
       for (int i = 0; i < indices_.size(); ++i)
@@ -354,8 +335,8 @@ CartPoseJacCalculator::CartPoseJacCalculator(
                                   tesseract::common::TransformMap& state_cache) -> VectorXd {
       manip_->calcFwdKin(state_cache, vals);
       const Isometry3d perturbed_source_tf = state_cache[source_frame_] * source_frame_offset_;
-      VectorXd error_diff =
-          tesseract::common::calcJacobianTransformErrorDiff(target_tf, source_tf, perturbed_source_tf);
+      VectorXd error_diff = tesseract::common::calcJacobianTransformErrorDiff(
+          target_tf, source_tf, perturbed_source_tf, lower_tolerance_, upper_tolerance_);
 
       VectorXd reduced_error_diff(indices_.size());
       for (int i = 0; i < indices_.size(); ++i)
@@ -368,6 +349,7 @@ CartPoseJacCalculator::CartPoseJacCalculator(
 
 MatrixXd CartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
 {
+  // Finite-difference jacobian of the (optionally toleranced) Cartesian error.
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -34,6 +34,28 @@ using Eigen::VectorXd;
 
 namespace trajopt
 {
+namespace
+{
+// Validate a (lower, upper) tolerance pair at construction time so the per-call FD-Jacobian path
+// in tesseract::common::applyTolerances can stay free of these checks.
+void validateTolerances(const char* who, const Eigen::VectorXd& lower, const Eigen::VectorXd& upper)
+{
+  if (lower.size() != upper.size())
+  {
+    std::stringstream ss;
+    ss << who << ": Mismatched tolerance sizes. lower: " << lower.size() << ", upper: " << upper.size();
+    throw std::runtime_error(ss.str());
+  }
+  if (lower.size() != 0 && (lower.array() > upper.array()).any())
+  {
+    std::stringstream ss;
+    ss << who << ": Inverted tolerance band — lower > upper at one or more indices. lower: [" << lower.transpose()
+       << "], upper: [" << upper.transpose() << "]";
+    throw std::runtime_error(ss.str());
+  }
+}
+}  // namespace
+
 DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
     std::shared_ptr<const tesseract::kinematics::JointGroup> manip,
     std::string source_frame,
@@ -52,13 +74,7 @@ DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
 {
   assert(indices_.size() <= 6);
 
-  if (lower_tolerance.size() != upper_tolerance.size())
-  {
-    std::stringstream error_ss;
-    error_ss << "DynamicCartPoseErrCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance.size()
-             << ", upper: " << upper_tolerance.size();
-    throw std::runtime_error(error_ss.str());
-  }
+  validateTolerances("DynamicCartPoseErrCalculator", lower_tolerance, upper_tolerance);
 
   // Check to see if the waypoint is toleranced and set the error function accordingly
   if ((lower_tolerance.size() == 0 && upper_tolerance.size() == 0) ||
@@ -136,13 +152,7 @@ DynamicCartPoseJacCalculator::DynamicCartPoseJacCalculator(
 {
   assert(indices_.size() <= 6);
 
-  if (lower_tolerance_.size() != upper_tolerance_.size())
-  {
-    std::stringstream error_ss;
-    error_ss << "DynamicCartPoseJacCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance_.size()
-             << ", upper: " << upper_tolerance_.size();
-    throw std::runtime_error(error_ss.str());
-  }
+  validateTolerances("DynamicCartPoseJacCalculator", lower_tolerance_, upper_tolerance_);
 }
 
 MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
@@ -193,13 +203,7 @@ CartPoseErrCalculator::CartPoseErrCalculator(
   assert(indices_.size() <= 6);
   is_target_active_ = manip_->isActiveLinkName(target_frame_);
 
-  if (lower_tolerance.size() != upper_tolerance.size())
-  {
-    std::stringstream error_ss;
-    error_ss << "CartPoseErrCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance.size()
-             << ", upper: " << upper_tolerance.size();
-    throw std::runtime_error(error_ss.str());
-  }
+  validateTolerances("CartPoseErrCalculator", lower_tolerance, upper_tolerance);
 
   // Check to see if the waypoint is toleranced and set the error function accordingly
   if ((lower_tolerance.size() == 0 && upper_tolerance.size() == 0) ||
@@ -301,13 +305,7 @@ CartPoseJacCalculator::CartPoseJacCalculator(
 {
   assert(indices_.size() <= 6);
 
-  if (lower_tolerance_.size() != upper_tolerance_.size())
-  {
-    std::stringstream error_ss;
-    error_ss << "CartPoseJacCalculator: Mismatched tolerance sizes. lower: " << lower_tolerance_.size()
-             << ", upper: " << upper_tolerance_.size();
-    throw std::runtime_error(error_ss.str());
-  }
+  validateTolerances("CartPoseJacCalculator", lower_tolerance_, upper_tolerance_);
 
   if (is_target_active_)
   {

--- a/trajopt/src/problem_description.cpp
+++ b/trajopt/src/problem_description.cpp
@@ -793,8 +793,14 @@ void DynamicCartPoseTermInfo::hatch(TrajOptProb& prob)
                                                             lower_tolerance,
                                                             upper_tolerance);
 
-    auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+    auto dfdx = std::make_shared<DynamicCartPoseJacCalculator>(prob.GetKin(),
+                                                               source_frame,
+                                                               target_frame,
+                                                               source_frame_offset,
+                                                               target_frame_offset,
+                                                               indices,
+                                                               lower_tolerance,
+                                                               upper_tolerance);
 
     // Apply error calculator as either cost or constraint
     if (static_cast<bool>(term_type & TermType::TT_COST))
@@ -941,8 +947,14 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      lower_tolerance,
                                                      upper_tolerance);
 
-    auto dfdx = std::make_shared<CartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+    auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
+                                                        source_frame,
+                                                        target_frame,
+                                                        source_frame_offset,
+                                                        target_frame_offset,
+                                                        indices,
+                                                        lower_tolerance,
+                                                        upper_tolerance);
     prob.addCost(
         std::make_shared<TrajOptCostFromErrFunc>(f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::ABS, name));
   }
@@ -957,8 +969,14 @@ void CartPoseTermInfo::hatch(TrajOptProb& prob)
                                                      lower_tolerance,
                                                      upper_tolerance);
 
-    auto dfdx = std::make_shared<CartPoseJacCalculator>(
-        prob.GetKin(), source_frame, target_frame, source_frame_offset, target_frame_offset, indices);
+    auto dfdx = std::make_shared<CartPoseJacCalculator>(prob.GetKin(),
+                                                        source_frame,
+                                                        target_frame,
+                                                        source_frame_offset,
+                                                        target_frame_offset,
+                                                        indices,
+                                                        lower_tolerance,
+                                                        upper_tolerance);
     prob.addConstraint(std::make_shared<TrajOptConstraintFromErrFunc>(
         f, dfdx, prob.GetVarRow(timestep, 0, n_dof), coeff, sco::EQ, name));
   }

--- a/trajopt/test/cart_position_optimization_unit.cpp
+++ b/trajopt/test/cart_position_optimization_unit.cpp
@@ -143,18 +143,33 @@ TEST(CartPositionOptimizationTrajoptSCO, cart_position_optimization_trajopt_sco)
 
 // ---------------------------------------------------------------------------
 // Helper: build ABB IRB2400 environment (shared by both discriminator tests).
+// Uses output references + ASSERT_* so a misconfigured resource locator or a
+// failed Environment::init() produces a clean gtest failure instead of a
+// null-pointer segfault.
 // ---------------------------------------------------------------------------
-static std::pair<std::shared_ptr<Environment>, tesseract::kinematics::JointGroup::ConstPtr> buildAbbIrb2400Env()
+static void buildAbbIrb2400Env(std::shared_ptr<Environment>& env_out,
+                               tesseract::kinematics::JointGroup::ConstPtr& manip_out)
 {
   const ResourceLocator::Ptr locator = std::make_shared<tesseract::common::GeneralResourceLocator>();
-  const std::filesystem::path urdf_path =
-      locator->locateResource("package://tesseract/support/urdf/abb_irb2400.urdf")->getFilePath();
-  const std::filesystem::path srdf_path =
-      locator->locateResource("package://tesseract/support/urdf/abb_irb2400.srdf")->getFilePath();
+
+  const auto urdf_resource = locator->locateResource("package://tesseract/support/urdf/abb_irb2400.urdf");
+  ASSERT_NE(urdf_resource, nullptr) << "Failed to locate abb_irb2400.urdf -- is TESSERACT_RESOURCE_PATH set?";
+  const auto srdf_resource = locator->locateResource("package://tesseract/support/urdf/abb_irb2400.srdf");
+  ASSERT_NE(srdf_resource, nullptr) << "Failed to locate abb_irb2400.srdf -- is TESSERACT_RESOURCE_PATH set?";
+
+  // NOTE: explicit std::filesystem::path conversion is required so init() resolves to the
+  // file-path overload rather than the urdf-string overload.
+  const std::filesystem::path urdf_path = urdf_resource->getFilePath();
+  const std::filesystem::path srdf_path = srdf_resource->getFilePath();
+
   auto env = std::make_shared<Environment>();
-  env->init(urdf_path, srdf_path, locator);
+  ASSERT_TRUE(env->init(urdf_path, srdf_path, locator)) << "Environment::init() failed for abb_irb2400";
+
   auto manip = env->getJointGroup("manipulator");
-  return { env, manip };
+  ASSERT_NE(manip, nullptr) << "JointGroup 'manipulator' not found in abb_irb2400";
+
+  env_out = std::move(env);
+  manip_out = std::move(manip);
 }
 
 // ---------------------------------------------------------------------------
@@ -199,8 +214,9 @@ TEST(CartPositionOptimizationTrajoptSCO, cart_position_seed_outside_band_snaps_t
   console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_NONE);
   trajopt_common::gLogLevel = trajopt_common::LevelError;
 
-  auto [env, manip] = buildAbbIrb2400Env();
-  ASSERT_NE(manip, nullptr);
+  std::shared_ptr<Environment> env;
+  tesseract::kinematics::JointGroup::ConstPtr manip;
+  ASSERT_NO_FATAL_FAILURE(buildAbbIrb2400Env(env, manip));
   ASSERT_EQ(manip->numJoints(), 6U);
 
   Eigen::VectorXd start_pos(6);
@@ -345,8 +361,9 @@ TEST(CartPositionOptimizationTrajoptSCO, cart_position_seed_inside_band_uses_ban
   console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_NONE);
   trajopt_common::gLogLevel = trajopt_common::LevelError;
 
-  auto [env, manip] = buildAbbIrb2400Env();
-  ASSERT_NE(manip, nullptr);
+  std::shared_ptr<Environment> env;
+  tesseract::kinematics::JointGroup::ConstPtr manip;
+  ASSERT_NO_FATAL_FAILURE(buildAbbIrb2400Env(env, manip));
   ASSERT_EQ(manip->numJoints(), 6U);
 
   Eigen::VectorXd start_pos(6);

--- a/trajopt/test/cart_position_optimization_unit.cpp
+++ b/trajopt/test/cart_position_optimization_unit.cpp
@@ -33,6 +33,7 @@ TRAJOPT_IGNORE_WARNINGS_PUSH
 #include <tesseract/environment/utils.h>
 #include <tesseract/common/resource_locator.h>
 #include <tesseract/common/types.h>
+#include <tesseract/common/utils.h>
 #include <console_bridge/console.h>
 TRAJOPT_IGNORE_WARNINGS_POP
 
@@ -138,4 +139,302 @@ TEST(CartPositionOptimizationTrajoptSCO, cart_position_optimization_trajopt_sco)
     std::cout << "Initial: " << prob->GetInitTraj() << '\n';
     std::cout << "Results: " << traj << '\n';
   }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build ABB IRB2400 environment (shared by both discriminator tests).
+// ---------------------------------------------------------------------------
+static std::pair<std::shared_ptr<Environment>, tesseract::kinematics::JointGroup::ConstPtr> buildAbbIrb2400Env()
+{
+  const ResourceLocator::Ptr locator = std::make_shared<tesseract::common::GeneralResourceLocator>();
+  const std::filesystem::path urdf_path =
+      locator->locateResource("package://tesseract/support/urdf/abb_irb2400.urdf")->getFilePath();
+  const std::filesystem::path srdf_path =
+      locator->locateResource("package://tesseract/support/urdf/abb_irb2400.srdf")->getFilePath();
+  auto env = std::make_shared<Environment>();
+  env->init(urdf_path, srdf_path, locator);
+  auto manip = env->getJointGroup("manipulator");
+  return { env, manip };
+}
+
+// ---------------------------------------------------------------------------
+// Discriminator Test A: seed outside the rz tolerance band -- band-interior
+// assertion.
+//
+// Bug symptom (pre-fix): the optimizer stops inside the band short of the
+// JointPos target.  Pre-fix, J[rz,joint_6] is non-zero even when rz is
+// inside the band, creating a spurious ABS-penalty row that resists joint_6
+// motion.  Post-fix: the Jac row is zero inside the band so JointPos moves
+// the joint freely to its target on the opposite side of the band.
+//
+// Mechanism: joint_6 (ABB IRB2400 tool-roll) creates rz error without any
+// TCP translation coupling (verified: joint_6=0.3 -> rz=0.3, tx/ty/tz=0).
+// Joints 0-4 are pinned via TT_CNT equality constraints so the problem is
+// effectively 1-DOF on joint_6.  This prevents the optimizer from using
+// redundant joints to compensate the rz Jacobian row.
+//
+// Setup:
+//   - start_pos  = [0, 0.5, -0.5, 0, 0.5, 0]
+//   - target_pose = FK(start_pos)
+//   - seed:  joint_6 += 0.9  (rz_err ~= 0.9, outside the +/-0.5 band)
+//   - CartPose TT_COST: wide bands on all six components
+//       tx/ty/tz +/-0.05 m, rx/ry/rz +/-0.5 rad, coeff = 10
+//   - TT_CNT pin on joints 0-4 at start_pos (coeff[0..4]=1, coeff[5]=0)
+//   - JointPos TT_COST: joint_6 target = start_pos[5] - 0.4 = -0.4 rad
+//                       (rz ~= -0.4, inside band on the OPPOSITE side)
+//                       coeff = 20.0 (ratio 10:20)
+//
+// The strong JointPos pull (2*20*0.9 = 36 >> CartPose resistance 10) causes
+// the SQP to overshoot the band edge by a small amount.  Once strictly inside
+// the band:
+//   Post-fix: J = 0 -> no resistance -> joint_6 reaches -0.4 exactly.
+//   Pre-fix: J[rz,j6] = 1 -> resistance = 10. Equilibrium at
+//            2*20*|c+0.4| = 10 -> c ~= -0.15.
+//            |opt[5] - (-0.4)| ~= 0.25 > 0.15 -> assertion fails.
+//
+// Stash-revert failure (observed): opt joint_6 ~= -0.15, gap ~= 0.25 > 0.15.
+// ---------------------------------------------------------------------------
+TEST(CartPositionOptimizationTrajoptSCO, cart_position_seed_outside_band_snaps_to_edge)  // NOLINT
+{
+  console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_NONE);
+  trajopt_common::gLogLevel = trajopt_common::LevelError;
+
+  auto [env, manip] = buildAbbIrb2400Env();
+  ASSERT_NE(manip, nullptr);
+  ASSERT_EQ(manip->numJoints(), 6U);
+
+  Eigen::VectorXd start_pos(6);
+  start_pos << 0.0, 0.5, -0.5, 0.0, 0.5, 0.0;
+  const Eigen::Isometry3d target_pose = manip->calcFwdKin(start_pos).at("tool0");
+
+  // Seed: joint_6 (index 5, tool-roll, axis [1,0,0] in link_5) perturbed +0.9
+  // rad so rz_err ~= 0.9 (outside the +/-0.5 band).
+  // joint_6 rotation does not change TCP translation (verified empirically).
+  Eigen::VectorXd seed_pos = start_pos;
+  seed_pos[5] += 0.9;
+
+  ProblemConstructionInfo pci(env);
+  pci.basic_info.n_steps = 1;
+  pci.basic_info.manip = "manipulator";
+  pci.basic_info.use_time = false;
+  pci.basic_info.convex_solver = sco::ModelType::OSQP;
+  pci.kin = manip;
+
+  pci.init_info.type = InitInfo::GIVEN_TRAJ;
+  pci.init_info.data = tesseract::common::TrajArray(1, manip->numJoints());
+  pci.init_info.data.row(0) = seed_pos.transpose();
+
+  // CartPose soft-penalty cost with WIDE bands on all six components.
+  // At seed: rz ~= 0.9 (outside +/-0.5) -> drives optimizer toward 0.
+  // Inside band: post-fix Jac = 0; pre-fix Jac non-zero -> resists crossing.
+  {
+    auto pose = std::make_shared<CartPoseTermInfo>();
+    pose->term_type = TermType::TT_COST;
+    pose->name = "cart_pose_wide_band_A";
+    pose->timestep = 0;
+    pose->source_frame = "tool0";
+    pose->target_frame = "base_link";
+    pose->target_frame_offset = target_pose;
+    pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
+    pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+    pose->lower_tolerance = (Eigen::VectorXd(6) << -0.05, -0.05, -0.05, -0.5, -0.5, -0.5).finished();
+    pose->upper_tolerance = (Eigen::VectorXd(6) << 0.05, 0.05, 0.05, 0.5, 0.5, 0.5).finished();
+    pci.cost_infos.push_back(pose);
+  }
+
+  // TT_CNT equality constraints to pin joints 0-4 at start_pos.
+  // coeff[5] = 0 means no constraint on joint_6 (free).
+  // Pinning joints 0-4 makes the problem 1-DOF on joint_6 and prevents the
+  // optimizer from using redundant joints to compensate the rz Jac row.
+  {
+    auto jp_pin = std::make_shared<JointPosTermInfo>();
+    jp_pin->term_type = TermType::TT_CNT;
+    jp_pin->name = "joint_pos_pin_A";
+    jp_pin->first_step = 0;
+    jp_pin->last_step = 0;
+    jp_pin->targets = std::vector<double>(start_pos.data(), start_pos.data() + start_pos.size());
+    jp_pin->coeffs = { 1.0, 1.0, 1.0, 1.0, 1.0, 0.0 };  // pin joints 0-4; coeff=0 disables joint_6's constraint row
+    pci.cnt_infos.push_back(jp_pin);
+  }
+
+  // JointPos cost: joint_6 target = -0.4 (rz ~= -0.4, INSIDE band from the
+  // OPPOSITE side).  coeff = 20.0.
+  // Post-fix: all Jac rows zero inside band -> optimizer crosses to -0.4.
+  // Pre-fix: J[rz,joint_6] != 0; inside band, equilibrium 2*20*|c+0.4| = 10
+  // -> c ~= -0.15, stalls short of the -0.4 target.
+  const double j6_target = start_pos[5] - 0.4;  // = -0.4
+  {
+    auto jp = std::make_shared<JointPosTermInfo>();
+    jp->term_type = TermType::TT_COST;
+    jp->name = "joint_pos_pull_A";
+    jp->first_step = 0;
+    jp->last_step = 0;
+    std::vector<double> targets(start_pos.data(), start_pos.data() + start_pos.size());
+    targets[5] = j6_target;  // joint_6 target = -0.4
+    jp->targets = targets;
+    // JointPos pull on joint_6: target = -0.4 (opposite side of the +0.5 band edge),
+    // coeff = 20 (CartPose:JointPos gradient ratio ~10:40 at seed; strong pull
+    // overshoots the band edge and enters the interior). Inside the band:
+    // post-fix J = 0 -> free to reach -0.4; pre-fix J = 1 -> stops at ~-0.15
+    // (where 2*20*|c+0.4| = 10 -> c ~= -0.15).
+    jp->coeffs = std::vector<double>(6, 20.0);
+    pci.cost_infos.push_back(jp);
+  }
+
+  auto prob = ConstructProblem(pci);
+  sco::BasicTrustRegionSQP opt(prob);
+  opt.initialize(trajToDblVec(prob->GetInitTraj()));
+  opt.optimize();
+
+  const tesseract::common::TrajArray traj = getTraj(opt.x(), prob->GetVars());
+  const Eigen::Isometry3d optimized_pose = manip->calcFwdKin(traj.row(0)).at("tool0");
+  const Eigen::VectorXd opt_joints = traj.row(0).transpose();
+
+  const Eigen::VectorXd pose_err = tesseract::common::calcTransformError(target_pose, optimized_pose);
+  const double rz_err_final = pose_err[5];
+
+  if (DEBUG)
+  {
+    std::cout << "[Test A] opt joint_6   = " << opt_joints[5] << "  (target = " << j6_target << ")\n";
+    std::cout << "[Test A] rz_err_final  = " << rz_err_final << " (expect inside +/-0.5)\n";
+    std::cout << "[Test A] pose_err      = " << pose_err.transpose() << "\n";
+  }
+
+  // Post-fix: once inside the band Jac rows = 0 -> JointPos free to cross to
+  // ~-0.4 -> |opt[5] - (-0.4)| < 0.15.
+  // Pre-fix: J[rz,joint_6] = 1 inside band -> resistance = 10.
+  // Equilibrium: 2*20*|c+0.4| = 10 -> c ~= -0.15.
+  // |opt[5] - (-0.4)| ~= 0.25 > 0.15 -> assertion fails.
+  EXPECT_LT(std::abs(opt_joints[5] - j6_target), 0.15)
+      << "joint_6 did not reach target: opt = " << opt_joints[5] << "  target = " << j6_target
+      << "  (pre-fix: stops short at ~-0.15, gap ~0.25)";
+
+  // rz must be inside the allowed band.
+  EXPECT_LT(std::abs(rz_err_final), 0.5) << "rz_err_final = " << rz_err_final << " outside band +/-0.5";
+}
+
+// ---------------------------------------------------------------------------
+// Discriminator Test B: seed inside ALL tolerance bands -- band-freedom
+// assertion.
+//
+// Bug symptom (pre-fix): the spurious non-zero Jac rows (CartPose Jac
+// ignoring tolerances when all errors are inside the band) resist any joint
+// motion and pin the joint at the seed.  Post-fix: all Jac rows are zero
+// inside the band and the JointPos cost can move the joint freely.
+//
+// joint_6 (tool-roll) is used as the motion joint because it creates rz error
+// with zero translation coupling (verified: joint_6=0.3 -> rz=0.3, others=0).
+//
+// Setup:
+//   - start_pos  = [0, 0.5, -0.5, 0, 0.5, 0]
+//   - target_pose = FK(start_pos)
+//   - seed_pos = start_pos (all pose errors = 0 -- inside all bands)
+//   - CartPose TT_COST: WIDE bands tx/ty/tz +/-0.05 m, rx/ry/rz +/-0.5 rad
+//     coeff = 10.  All errors = 0 at seed -> all components in-band.
+//     Post-fix: all six Jac rows = 0 inside band -> no CartPose gradient.
+//     Pre-fix: Jac is raw (tolerance-blind) -> non-zero even when err = 0.
+//   - JointPos TT_COST: joint_6 target = start_pos[5] + 0.3 = 0.3, coeff=1.
+//     At joint_6 = 0.3: rz ~= 0.3 (inside +/-0.5), translation ~= 0.
+//     Post-fix: no resistance -> joint_6 moves to 0.3.
+//     Pre-fix: non-zero Jac (ratio 10 >> 1) blocks motion -> joint_6 ~= 0.
+//
+// Stash-revert failure (observed): opt joint_6 = 0 -> |opt[5] - 0.3| = 0.3.
+// ---------------------------------------------------------------------------
+TEST(CartPositionOptimizationTrajoptSCO, cart_position_seed_inside_band_uses_band_freedom)  // NOLINT
+{
+  console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_NONE);
+  trajopt_common::gLogLevel = trajopt_common::LevelError;
+
+  auto [env, manip] = buildAbbIrb2400Env();
+  ASSERT_NE(manip, nullptr);
+  ASSERT_EQ(manip->numJoints(), 6U);
+
+  Eigen::VectorXd start_pos(6);
+  start_pos << 0.0, 0.5, -0.5, 0.0, 0.5, 0.0;
+  const Eigen::Isometry3d target_pose = manip->calcFwdKin(start_pos).at("tool0");
+
+  // Seed = start_pos: all pose errors = 0 -- all components inside all bands.
+
+  ProblemConstructionInfo pci(env);
+  pci.basic_info.n_steps = 1;
+  pci.basic_info.manip = "manipulator";
+  pci.basic_info.use_time = false;
+  pci.basic_info.convex_solver = sco::ModelType::OSQP;
+  pci.kin = manip;
+
+  pci.init_info.type = InitInfo::GIVEN_TRAJ;
+  pci.init_info.data = tesseract::common::TrajArray(1, manip->numJoints());
+  pci.init_info.data.row(0) = start_pos.transpose();
+
+  // CartPose soft-penalty cost with WIDE bands on all six components.
+  // At the seed every component = 0 -> all in-band.
+  // Post-fix: all six Jac rows = 0 (err=0, perturbed_err=0 for small motion
+  // inside the band) -> no CartPose gradient -> JointPos dominates.
+  // Pre-fix: Jac is raw (tolerance-blind) -> non-zero even when err = 0
+  // -> resists any joint motion.
+  {
+    auto pose = std::make_shared<CartPoseTermInfo>();
+    pose->term_type = TermType::TT_COST;
+    pose->name = "cart_pose_wide_band_B";
+    pose->timestep = 0;
+    pose->source_frame = "tool0";
+    pose->target_frame = "base_link";
+    pose->target_frame_offset = target_pose;
+    pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
+    pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+    // Translation bands +/-0.05 m, rotation bands +/-0.5 rad.
+    // At joint_6 = 0.3 rad: rz ~= 0.3 (inside +/-0.5), translation ~= 0.
+    pose->lower_tolerance = (Eigen::VectorXd(6) << -0.05, -0.05, -0.05, -0.5, -0.5, -0.5).finished();
+    pose->upper_tolerance = (Eigen::VectorXd(6) << 0.05, 0.05, 0.05, 0.5, 0.5, 0.5).finished();
+    pci.cost_infos.push_back(pose);
+  }
+
+  // JointPos cost: joint_6 target = start_pos[5] + 0.3 = 0.3, coeff = 1.0.
+  // The resulting rz change (~0.3) stays inside the +/-0.5 band.
+  // Post-fix: all Jac rows = 0 -> optimizer moves freely -> joint_6 ~= 0.3.
+  // Pre-fix: non-zero Jac rows (CartPose coeff 10 >> JointPos coeff 1)
+  // resist motion -> joint_6 stays near 0.0.
+  const double delta_j6 = 0.3;
+  {
+    auto jp = std::make_shared<JointPosTermInfo>();
+    jp->term_type = TermType::TT_COST;
+    jp->name = "joint_pos_pull_B";
+    jp->first_step = 0;
+    jp->last_step = 0;
+    std::vector<double> targets(start_pos.data(), start_pos.data() + start_pos.size());
+    targets[5] += delta_j6;  // joint_6 target = 0.3
+    jp->targets = targets;
+    jp->coeffs = std::vector<double>(6, 1.0);
+    pci.cost_infos.push_back(jp);
+  }
+
+  auto prob = ConstructProblem(pci);
+  sco::BasicTrustRegionSQP opt(prob);
+  opt.initialize(trajToDblVec(prob->GetInitTraj()));
+  opt.optimize();
+
+  const tesseract::common::TrajArray traj = getTraj(opt.x(), prob->GetVars());
+  const Eigen::Isometry3d optimized_pose = manip->calcFwdKin(traj.row(0)).at("tool0");
+  const Eigen::VectorXd opt_joints = traj.row(0).transpose();
+
+  const Eigen::VectorXd pose_err = tesseract::common::calcTransformError(target_pose, optimized_pose);
+  const double rz_err_final = pose_err[5];
+
+  if (DEBUG)
+  {
+    std::cout << "[Test B] opt joint_6   = " << opt_joints[5] << "  (target = " << (start_pos[5] + delta_j6) << ")\n";
+    std::cout << "[Test B] rz_err_final  = " << rz_err_final << " (expect inside +/-0.5)\n";
+    std::cout << "[Test B] pose_err      = " << pose_err.transpose() << "\n";
+  }
+
+  // Post-fix: joint_6 must reach its JointPos target (all Jac rows = 0 inside
+  // the wide bands -> no resistance from CartPose).
+  // Pre-fix: non-zero Jac rows (CartPose coeff 10 >> JointPos coeff 1) resist
+  // motion -> joint_6 stays near 0 -> this assertion fails.
+  EXPECT_LT(std::abs(opt_joints[5] - (start_pos[5] + delta_j6)), 0.1)
+      << "joint_6 did not move to target: opt = " << opt_joints[5] << "  target = " << (start_pos[5] + delta_j6)
+      << "  (pre-fix: joint pinned near " << start_pos[5] << ")";
+
+  // rz must stay within the allowed band.
+  EXPECT_LT(std::abs(rz_err_final), 0.5) << "rz_err_final = " << rz_err_final << " outside band +/-0.5";
 }

--- a/trajopt/test/kinematic_costs_unit.cpp
+++ b/trajopt/test/kinematic_costs_unit.cpp
@@ -96,40 +96,283 @@ TEST_F(KinematicCostsTest, CartPoseJacCalculator)  // NOLINT
   checkJacobian(f, dfdx, values, 1.0e-5);
 }
 
-// This has known issues and is not being used. Disabled due to segfaults in CI
-// TEST_F(KinematicCostsTest, DynamicCartPoseJacCalculator)  // NOLINT
-//{
-//  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, DynamicCartPoseJacCalculator");
+TEST_F(KinematicCostsTest, CartPoseJacCalculator_TolerancedInsideBand)  // NOLINT
+{
+  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, CartPoseJacCalculator_TolerancedInsideBand");
 
-//  auto env = env_->getEnvironment();
-//  auto kin = env_->getManipulatorManager()->getFwdKinematicSolver("full_body");
-//  std::unordered_map<std::string, double> j;
-//  j["l_elbow_flex_joint"] = -0.15;
-//  env->setState(j);
-//  auto world_to_base = env->getCurrentState()->link_transforms.at(kin->getBaseLinkName());
-//  auto adjacency_map = std::make_shared<tesseract::environment::AdjacencyMap>(
-//      env->getSceneGraph(), kin->getActiveLinkNames(), env->getCurrentState()->link_transforms);
+  const tesseract::kinematics::JointGroup::ConstPtr kin = env_->getJointGroup("right_arm");
 
-//  std::string link = "r_gripper_tool_frame";
-//  std::string target = "l_gripper_tool_frame";
-//  Eigen::Isometry3d tcp = Eigen::Isometry3d::Identity();
+  const std::string source_frame = env_->getRootLinkName();
+  const std::string target_frame = "r_gripper_tool_frame";
 
-//  Eigen::VectorXd values(15);
-//  values.setZero();
-//  std::vector<std::string> joint_names = kin->getJointNames();
-//  for (std::size_t i = 0; i < 15; ++i)
-//  {
-//    if (joint_names[i] == "r_elbow_flex_joint" || joint_names[i] == "l_elbow_flex_joint")
-//      values(static_cast<long>(i)) = -0.15;
+  // Seed configuration. We then construct target_frame_offset so that the pose error at this seed is +0.1 rad about
+  // x and zero everywhere else (well inside the ±0.52 band on rx).
+  Eigen::VectorXd values(7);
+  values << -1.1, 1.2, -3.3, -1.4, 5.5, -1.6, 7.7;
 
-//    if (joint_names[i] == "r_wrist_flex_joint" || joint_names[i] == "l_wrist_flex_joint")
-//      values(static_cast<long>(i)) = -0.1;
-//  }
+  const tesseract::common::TransformMap state_cache = kin->calcFwdKin(values);
+  const Eigen::Isometry3d& source_frame_offset = state_cache.at(target_frame);
+  const Eigen::Isometry3d target_frame_offset =
+      Eigen::Isometry3d::Identity() * Eigen::AngleAxisd(0.1, Eigen::Vector3d::UnitX());
 
-//  DynamicCartPoseErrCalculator f(target, kin, adjacency_map, world_to_base, link, tcp, tcp);
-//  DynamicCartPoseJacCalculator dfdx(target, kin, adjacency_map, world_to_base, link, tcp, tcp);
-//  checkJacobian(f, dfdx, values, 1.0e-5);
-//}
+  Eigen::VectorXd lower(6);
+  Eigen::VectorXd upper(6);
+  lower << 0.0, 0.0, 0.0, -0.52, 0.0, 0.0;
+  upper << 0.0, 0.0, 0.0, 0.52, 0.0, 0.0;
+
+  const Eigen::VectorXi indices = (Eigen::VectorXi(6) << 0, 1, 2, 3, 4, 5).finished();
+
+  const CartPoseErrCalculator f(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+  const CartPoseJacCalculator dfdx(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+
+  // (a) f at the seed must be zero — rx error is in the band, others are exactly zero by construction.
+  const Eigen::VectorXd err_at_seed = f(values);
+  EXPECT_TRUE(err_at_seed.isZero(1e-9)) << "Toleranced error at seed should be zero inside band, got: "
+                                        << err_at_seed.transpose();
+
+  // (b) The smoking gun: the rx row of the analytical Jacobian must be ~0. f is identically zero on an open
+  //     neighborhood of the seed in rx (band half-width 0.52, seed 0.1 rad in), so the analytical gradient w.r.t.
+  //     rx must vanish.
+  const Eigen::MatrixXd analytical = dfdx(values);
+  EXPECT_TRUE(analytical.row(3).isZero(1e-6))
+      << "rx row of toleranced Jacobian must be zero inside band, got: " << analytical.row(3);
+
+  // (c) Consistency: numerical FD of toleranced f must equal analytical Jac.
+  checkJacobian(f, dfdx, values, 1.0e-5);
+}
+
+TEST_F(KinematicCostsTest, CartPoseJacCalculator_TolerancedOutsideBand)  // NOLINT
+{
+  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, CartPoseJacCalculator_TolerancedOutsideBand");
+
+  const tesseract::kinematics::JointGroup::ConstPtr kin = env_->getJointGroup("right_arm");
+
+  const std::string source_frame = env_->getRootLinkName();
+  const std::string target_frame = "r_gripper_tool_frame";
+
+  Eigen::VectorXd values(7);
+  values << -1.1, 1.2, -3.3, -1.4, 5.5, -1.6, 7.7;
+
+  const tesseract::common::TransformMap state_cache = kin->calcFwdKin(values);
+  const Eigen::Isometry3d& source_frame_offset = state_cache.at(target_frame);
+  // 0.8 rad rx offset, well outside the ±0.52 band.
+  const Eigen::Isometry3d target_frame_offset =
+      Eigen::Isometry3d::Identity() * Eigen::AngleAxisd(0.8, Eigen::Vector3d::UnitX());
+
+  Eigen::VectorXd lower(6);
+  Eigen::VectorXd upper(6);
+  lower << 0.0, 0.0, 0.0, -0.52, 0.0, 0.0;
+  upper << 0.0, 0.0, 0.0, 0.52, 0.0, 0.0;
+
+  const Eigen::VectorXi indices = (Eigen::VectorXi(6) << 0, 1, 2, 3, 4, 5).finished();
+
+  const CartPoseErrCalculator f(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+  const CartPoseJacCalculator dfdx(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+
+  // f is non-zero outside the band: f = (true_err - upper) on rx.
+  EXPECT_FALSE(f(values).isZero(1e-9));
+
+  // Numerical FD of f̃ equals analytical Jac. (Outside the band, f̃ is just f shifted by a constant — the constant
+  // cancels in the FD difference, so this would also pass under the old buggy implementation.)
+  checkJacobian(f, dfdx, values, 1.0e-5);
+}
+
+TEST_F(KinematicCostsTest, CartPoseJacCalculator_TolerancedAcrossEdge)  // NOLINT
+{
+  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, CartPoseJacCalculator_TolerancedAcrossEdge");
+
+  const tesseract::kinematics::JointGroup::ConstPtr kin = env_->getJointGroup("right_arm");
+
+  const std::string source_frame = env_->getRootLinkName();
+  const std::string target_frame = "r_gripper_tool_frame";
+
+  Eigen::VectorXd values(7);
+  values << -1.1, 1.2, -3.3, -1.4, 5.5, -1.6, 7.7;
+
+  const tesseract::common::TransformMap state_cache = kin->calcFwdKin(values);
+  const Eigen::Isometry3d& source_frame_offset = state_cache.at(target_frame);
+  // 0.51 rad rx — just inside the band, so any non-trivial perturbation around the edge straddles it.
+  const Eigen::Isometry3d target_frame_offset =
+      Eigen::Isometry3d::Identity() * Eigen::AngleAxisd(0.51, Eigen::Vector3d::UnitX());
+
+  Eigen::VectorXd lower(6);
+  Eigen::VectorXd upper(6);
+  lower << 0.0, 0.0, 0.0, -0.52, 0.0, 0.0;
+  upper << 0.0, 0.0, 0.0, 0.52, 0.0, 0.0;
+
+  const Eigen::VectorXi indices = (Eigen::VectorXi(6) << 0, 1, 2, 3, 4, 5).finished();
+
+  const CartPoseErrCalculator f(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+  const CartPoseJacCalculator dfdx(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+
+  // f is zero at the seed (0.51 is inside [-0.52, 0.52]).
+  EXPECT_TRUE(f(values).isZero(1e-9));
+
+  // FD-check the analytical Jac at small epsilons (which stay inside the band).
+  // Larger epsilons (1e-3, 1e-2, 1e-1) are excluded: this seed is only 0.01 rad from the upper edge, so even a
+  // moderate joint perturbation can carry the rotational error across the band boundary through the kinematic chain.
+  // When that happens the numerical FD secant mixes "inside" and "outside" behaviour while the analytical Jac (which
+  // uses DEFAULT_EPSILON ~ 1e-5 internally) stays squarely inside — producing genuine, unavoidable FD inaccuracy that
+  // is NOT a Jacobian bug. The two small epsilons below are sufficient to catch a naive row-zeroing shortcut: such a
+  // fix would zero rows 0-2 and 4-5 (non-rx DOFs), which the numerical FD at these epsilons would immediately expose.
+  checkJacobian(f, dfdx, values, 1.0e-7);
+  checkJacobian(f, dfdx, values, 1.0e-5);
+}
+
+TEST_F(KinematicCostsTest, DynamicCartPoseJacCalculator_TolerancedInsideBand)  // NOLINT
+{
+  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, DynamicCartPoseJacCalculator_TolerancedInsideBand");
+
+  const tesseract::kinematics::JointGroup::ConstPtr kin = env_->getJointGroup("right_arm");
+
+  // Both frames must be active for the dynamic variant. r_gripper_tool_frame and r_wrist_roll_link both move with
+  // the right arm joints in the pr2 srdf.
+  const std::string source_frame = "r_gripper_tool_frame";
+  const std::string target_frame = "r_wrist_roll_link";
+
+  Eigen::VectorXd values(7);
+  values << -1.1, 1.2, -3.3, -1.4, 5.5, -1.6, 7.7;
+
+  const tesseract::common::TransformMap state_cache = kin->calcFwdKin(values);
+  const Eigen::Isometry3d source_frame_offset = Eigen::Isometry3d::Identity();
+  // Pick a target_frame_offset such that the seed pose error has rx inside ±0.52 (e.g. 0.1 rad). Concretely: compute
+  // current_target_in_source = source_tf.inverse() * target_tf at the seed, then target_frame_offset =
+  // current_target_in_source.inverse() * AngleAxis(0.1, x) so the err vector at the seed is +/-0.1 about x and zero
+  // elsewhere.
+  // Error formula: err = calcTransformError(target_tf, source_tf) = target_tf.inverse() * source_tf.
+  // With source_frame_offset = I: source_tf = state_cache[source_frame].
+  // With target_frame_offset below: target_tf = state_cache[target_frame] * target_frame_offset.
+  // At seed, target_tf = wrist_tf * wrist_tf^-1 * gripper_tf * AngleAxis(0.1, x) = gripper_tf * AngleAxis(0.1, x).
+  // So err = (gripper_tf * AngleAxis(0.1,x))^-1 * gripper_tf = AngleAxis(-0.1, x). err[3] = -0.1 inside [-0.52, 0.52].
+  const Eigen::Isometry3d& source_tf_seed = state_cache.at(source_frame);
+  const Eigen::Isometry3d& target_tf_seed = state_cache.at(target_frame);
+  const Eigen::Isometry3d current_target_in_source = source_tf_seed.inverse() * target_tf_seed;
+  const Eigen::Isometry3d target_frame_offset =
+      current_target_in_source.inverse() * Eigen::Isometry3d(Eigen::AngleAxisd(0.1, Eigen::Vector3d::UnitX()));
+
+  Eigen::VectorXd lower(6);
+  Eigen::VectorXd upper(6);
+  lower << 0.0, 0.0, 0.0, -0.52, 0.0, 0.0;
+  upper << 0.0, 0.0, 0.0, 0.52, 0.0, 0.0;
+
+  const Eigen::VectorXi indices = (Eigen::VectorXi(6) << 0, 1, 2, 3, 4, 5).finished();
+
+  const DynamicCartPoseErrCalculator f(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+  const DynamicCartPoseJacCalculator dfdx(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+
+  // (a) f at the seed must be zero — rx error is in the band, others are exactly zero by construction.
+  EXPECT_TRUE(f(values).isZero(1e-9));
+
+  // (b) The smoking gun: the rx row of the analytical Jacobian must be ~0. f is identically zero on an open
+  //     neighborhood of the seed in rx (band half-width 0.52, seed 0.1 rad in), so the analytical gradient w.r.t.
+  //     rx must vanish.
+  const Eigen::MatrixXd analytical = dfdx(values);
+  EXPECT_TRUE(analytical.row(3).isZero(1e-6))
+      << "rx row of toleranced dynamic Jacobian must be zero inside band, got: " << analytical.row(3);
+
+  // (c) Consistency: numerical FD of toleranced f must equal analytical Jac.
+  checkJacobian(f, dfdx, values, 1.0e-5);
+}
+
+TEST_F(KinematicCostsTest, DynamicCartPoseJacCalculator_TolerancedOutsideBand)  // NOLINT
+{
+  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, DynamicCartPoseJacCalculator_TolerancedOutsideBand");
+
+  const tesseract::kinematics::JointGroup::ConstPtr kin = env_->getJointGroup("right_arm");
+
+  const std::string source_frame = "r_gripper_tool_frame";
+  const std::string target_frame = "r_wrist_roll_link";
+
+  Eigen::VectorXd values(7);
+  values << -1.1, 1.2, -3.3, -1.4, 5.5, -1.6, 7.7;
+
+  const tesseract::common::TransformMap state_cache = kin->calcFwdKin(values);
+  const Eigen::Isometry3d source_frame_offset = Eigen::Isometry3d::Identity();
+  // 0.8 rad rx offset, well outside the ±0.52 band. Same construction as InsideBand but with a larger angle.
+  // current_target_in_source = source_tf^-1 * target_tf at the seed.
+  // target_frame_offset = current_target_in_source^-1 * AngleAxis(0.8, x)
+  // => at seed, err[3] ≈ -0.8 which is outside [-0.52, 0.52].
+  const Eigen::Isometry3d& source_tf_seed = state_cache.at(source_frame);
+  const Eigen::Isometry3d& target_tf_seed = state_cache.at(target_frame);
+  const Eigen::Isometry3d current_target_in_source = source_tf_seed.inverse() * target_tf_seed;
+  const Eigen::Isometry3d target_frame_offset =
+      current_target_in_source.inverse() * Eigen::Isometry3d(Eigen::AngleAxisd(0.8, Eigen::Vector3d::UnitX()));
+
+  Eigen::VectorXd lower(6);
+  Eigen::VectorXd upper(6);
+  lower << 0.0, 0.0, 0.0, -0.52, 0.0, 0.0;
+  upper << 0.0, 0.0, 0.0, 0.52, 0.0, 0.0;
+
+  const Eigen::VectorXi indices = (Eigen::VectorXi(6) << 0, 1, 2, 3, 4, 5).finished();
+
+  const DynamicCartPoseErrCalculator f(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+  const DynamicCartPoseJacCalculator dfdx(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+
+  // f is non-zero outside the band: err[3] ≈ -0.8 - (-0.52) = -0.28 (clamped residual).
+  EXPECT_FALSE(f(values).isZero(1e-9));
+
+  // Numerical FD of f̃ equals analytical Jac. (Outside the band, f̃ is just f shifted by a constant — the constant
+  // cancels in the FD difference, so this would also pass under the old buggy implementation. This test is a
+  // regression guard, not a pre/post-fix discriminator.)
+  checkJacobian(f, dfdx, values, 1.0e-5);
+}
+
+TEST_F(KinematicCostsTest, DynamicCartPoseJacCalculator_TolerancedAcrossEdge)  // NOLINT
+{
+  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, DynamicCartPoseJacCalculator_TolerancedAcrossEdge");
+
+  const tesseract::kinematics::JointGroup::ConstPtr kin = env_->getJointGroup("right_arm");
+
+  const std::string source_frame = "r_gripper_tool_frame";
+  const std::string target_frame = "r_wrist_roll_link";
+
+  Eigen::VectorXd values(7);
+  values << -1.1, 1.2, -3.3, -1.4, 5.5, -1.6, 7.7;
+
+  const tesseract::common::TransformMap state_cache = kin->calcFwdKin(values);
+  const Eigen::Isometry3d source_frame_offset = Eigen::Isometry3d::Identity();
+  // 0.51 rad rx — just inside the band, so any non-trivial perturbation straddles the edge. Same pattern as
+  // InsideBand but with a larger angle close to the band boundary.
+  const Eigen::Isometry3d& source_tf_seed = state_cache.at(source_frame);
+  const Eigen::Isometry3d& target_tf_seed = state_cache.at(target_frame);
+  const Eigen::Isometry3d current_target_in_source = source_tf_seed.inverse() * target_tf_seed;
+  const Eigen::Isometry3d target_frame_offset =
+      current_target_in_source.inverse() * Eigen::Isometry3d(Eigen::AngleAxisd(0.51, Eigen::Vector3d::UnitX()));
+
+  Eigen::VectorXd lower(6);
+  Eigen::VectorXd upper(6);
+  lower << 0.0, 0.0, 0.0, -0.52, 0.0, 0.0;
+  upper << 0.0, 0.0, 0.0, 0.52, 0.0, 0.0;
+
+  const Eigen::VectorXi indices = (Eigen::VectorXi(6) << 0, 1, 2, 3, 4, 5).finished();
+
+  const DynamicCartPoseErrCalculator f(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+  const DynamicCartPoseJacCalculator dfdx(
+      kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper);
+
+  // f is zero at the seed (0.51 is inside [-0.52, 0.52]).
+  EXPECT_TRUE(f(values).isZero(1e-9));
+
+  // FD-check the analytical Jac. The dynamic variant involves two moving frames, which produces higher baseline
+  // numerical noise than the static variant — 1e-7 epsilon makes isApprox(1e-5) unreliable because both the
+  // numerical and analytical values are O(1e-10~12) (the function is identically zero on a band neighbourhood, so
+  // both quantities are essentially noise). Using 1e-5 epsilon keeps the FD secant well inside the band while
+  // avoiding noise-dominated comparisons. This epsilon is sufficient to catch a naive row-zeroing shortcut.
+  // NOTE: stash-reverting calcJacobianTransformErrorDiff tolerance handling SHOULD cause this test to fail —
+  // the band-edge sub-gradient is the discriminating case.
+  checkJacobian(f, dfdx, values, 1.0e-5);
+}
 
 ////////////////////////////////////////////////////////////////////
 

--- a/trajopt/test/kinematic_costs_unit.cpp
+++ b/trajopt/test/kinematic_costs_unit.cpp
@@ -374,6 +374,38 @@ TEST_F(KinematicCostsTest, DynamicCartPoseJacCalculator_TolerancedAcrossEdge)  /
   checkJacobian(f, dfdx, values, 1.0e-5);
 }
 
+// All four CartPose calculator constructors validate the (lower, upper) tolerance pair at
+// construction time so the FD-Jacobian hot path doesn't pay for a per-call check. An inverted
+// band (lower > upper on any component) must throw rather than producing a silent non-zero
+// result inside what looks like the dead-band.
+TEST_F(KinematicCostsTest, CartPoseCalculators_InvertedToleranceBandThrows)  // NOLINT
+{
+  const tesseract::kinematics::JointGroup::ConstPtr kin = env_->getJointGroup("right_arm");
+  const std::string source_frame = env_->getRootLinkName();
+  const std::string target_frame = "r_gripper_tool_frame";
+  const Eigen::Isometry3d source_frame_offset = Eigen::Isometry3d::Identity();
+  const Eigen::Isometry3d target_frame_offset = Eigen::Isometry3d::Identity();
+  const Eigen::VectorXi indices = (Eigen::VectorXi(6) << 0, 1, 2, 3, 4, 5).finished();
+
+  Eigen::VectorXd lower(6);
+  Eigen::VectorXd upper(6);
+  lower << 0.0, 0.0, 0.0, 0.5, 0.0, 0.0;   // rx lower = 0.5
+  upper << 0.0, 0.0, 0.0, -0.5, 0.0, 0.0;  // rx upper = -0.5  → inverted
+
+  EXPECT_THROW(CartPoseErrCalculator(
+                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
+               std::runtime_error);
+  EXPECT_THROW(CartPoseJacCalculator(
+                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
+               std::runtime_error);
+  EXPECT_THROW(DynamicCartPoseErrCalculator(
+                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
+               std::runtime_error);
+  EXPECT_THROW(DynamicCartPoseJacCalculator(
+                   kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
+               std::runtime_error);
+}
+
 ////////////////////////////////////////////////////////////////////
 
 int main(int argc, char** argv)


### PR DESCRIPTION
  ## Summary

  - Forward `lower_tolerance` / `upper_tolerance` from `CartPoseTermInfo` and `DynamicCartPoseTermInfo` to the Jac calculators, which now pass them to `tesseract::common::calcJacobianTransformErrorDiff` so the FD Jacobian stays
  consistent with the toleranced error function.
  - Replace the local `applyTolerances` copy with the shared `tesseract::common::applyTolerances` helper.

  **Depends on https://github.com/tesseract-robotics/tesseract/pull/1299** for the new helper and the optional tolerance args on `calcJacobianTransformErrorDiff`.

  ## Context

  Pre-fix, `CartPoseTermInfo::hatch()` (and the dynamic equivalent) forwarded the waypoint tolerance vectors to the error calculator but not to the Jacobian calculator — so SCO's linearisation paired a toleranced error function with a
  raw, untoleranced Jacobian. When the current point sat inside the band on some DOF (say rx), the error function correctly returned 0 for that component but the Jacobian still had a non-zero row, so the QP added a spurious `J[rx]·dq =
  0` constraint that pinned joint motion even when rx was free to move within the band.

For reference, the PR introducing toleranced Cartesian waypoints: https://github.com/tesseract-robotics/trajopt/pull/354

  ## Test plan

  New `KinematicCostsTest.{CartPose,DynamicCartPose}JacCalculator_*` tests cover in-band (Jacobian row zero inside the band), outside-band (Jacobian unchanged from the no-tolerance path), and across-edge (mixed sub-gradient row) for
  both static and dynamic variants. Two new SCO-level tests in `cart_position_optimization_unit.cpp` exercise the fix end-to-end on a 6-DOF ABB IRB2400: one where the seed sits outside the tolerance band and must snap to the edge, one
  where the seed is inside and the optimizer must use the band's freedom (the latter fails pre-fix). Full trajopt ctest suite (35/35) passes locally.