### PR TITLE
Updated debian package CI build

### DIFF
--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -7,45 +7,30 @@ on:
 
   # allow manually starting this workflow
   workflow_dispatch:
+    inputs:
+      major_version:
+        description: 'Major Version'
+        required: true
+        type: string
+      minor_version:
+        description: 'Minor Version'
+        required: true
+        type: string
+      patch_version:
+        description: 'Patch Version'
+        required: true
+        type: string
 
 jobs:
-  get-tag:
-    # Pre-job to fetch the latest tag
-    runs-on: ubuntu-latest
-    outputs:
-      major: ${{ steps.extract_tag.outputs.major }}
-      minor: ${{ steps.extract_tag.outputs.minor }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Ensure all history and tags are fetched
-
-      - name: Get latest tag
-        id: extract_tag
-        run: |
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "Latest tag: $latest_tag"
-
-          # Extract major and minor version from the tag
-          IFS='.' read -r major minor patch <<< "$latest_tag"
-          echo "Major: $major"
-          echo "Minor: $minor"
-
-          # Set as output variables
-          echo "::set-output name=major::$major"
-          echo "::set-output name=minor::$minor"
-
   Debian:
     name: ${{ matrix.distro }}
-    needs: get-tag  # Make sure the 'ci' job waits for the 'get-tag' job to finish
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         distro: [jammy, noble]
     container:
-      image: ghcr.io/tesseract-robotics/tesseract:${{ matrix.distro }}-${{ needs.get-tag.outputs.major }}.${{ needs.get-tag.outputs.minor }}
+      image: ghcr.io/tesseract-robotics/tesseract:${{ matrix.distro }}-${{ github.event.inputs.major_version }}.${{ github.event.inputs.minor_version }}
       env:
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
@@ -55,6 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: target_ws/src
+          ref: ${{ github.event.inputs.major_version }}.${{ github.event.inputs.minor_version }}.${{ github.event.inputs.patch_version }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Updates the debian package build CI job to be triggered correctly for past versions. Corresponds to https://github.com/tesseract-robotics/tesseract_planning/pull/750