### PR TITLE
Remove -mno-avx gcc compiler flag

### DIFF
--- a/trajopt_common/cmake/trajopt_macros.cmake
+++ b/trajopt_common/cmake/trajopt_macros.cmake
@@ -60,21 +60,6 @@ macro(trajopt_variables)
           -Wconversion
           -Wsign-conversion
           -Wno-sign-compare)
-      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
-      if(NOT
-         CMAKE_SYSTEM_NAME2
-         MATCHES
-         "aarch64"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "armv7l"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "unknown")
-        set(TRAJOPT_COMPILE_OPTIONS_PUBLIC -mno-avx)
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TRAJOPT_COMPILE_OPTIONS_PRIVATE
           -Wall
@@ -96,21 +81,6 @@ macro(trajopt_variables)
           -Werror=conversion
           -Werror=sign-conversion
           -Wno-sign-compare)
-      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
-      if(NOT
-         CMAKE_SYSTEM_NAME2
-         MATCHES
-         "aarch64"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "armv7l"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "unknown")
-        set(TRAJOPT_COMPILE_OPTIONS_PUBLIC -mno-avx)
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TRAJOPT_COMPILE_OPTIONS_PRIVATE
           -Werror=all


### PR DESCRIPTION
The `-mno-avx` gcc compiler flag does not appear to be necessary with modern gcc versions.