### PR TITLE
Fix cmake AppleClang detection

### DIFF
--- a/trajopt_common/cmake/trajopt_macros.cmake
+++ b/trajopt_common/cmake/trajopt_macros.cmake
@@ -75,7 +75,7 @@ macro(trajopt_variables)
              "unknown")
         set(TRAJOPT_COMPILE_OPTIONS_PUBLIC -mno-avx)
       endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TRAJOPT_COMPILE_OPTIONS_PRIVATE
           -Wall
           -Wextra
@@ -111,7 +111,7 @@ macro(trajopt_variables)
              "unknown")
         set(TRAJOPT_COMPILE_OPTIONS_PUBLIC -mno-avx)
       endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TRAJOPT_COMPILE_OPTIONS_PRIVATE
           -Werror=all
           -Werror=extra


### PR DESCRIPTION
This PR fixes cmake AppleClang detection. Updates to use:

```
CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*"
```

to correctly detect the AppleClang compiler.