### PR TITLE
Update OsqpEigen version to 0.11.2

### DIFF
--- a/trajopt_ext/osqp_eigen/CMakeLists.txt
+++ b/trajopt_ext/osqp_eigen/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(ros_industrial_cmake_boilerplate REQUIRED)
 extract_package_metadata(pkg)
 project(OsqpEigen_Ext VERSION ${pkg_extracted_version} LANGUAGES CXX)
 
-set(TRAJOPT_OSQPEIGEN_VERSION "0.11.0")
+set(TRAJOPT_OSQPEIGEN_VERSION "0.11.2")
 # Remove patch version for find_package
 string(
   REGEX


### PR DESCRIPTION
Upgrade OsqpEigen to 0.11.2 to allow uncommenting [lhs.setAdaptiveRhoFraction](https://github.com/tesseract-robotics/tesseract_planning/blob/0.35.0/motion_planners/trajopt_ifopt/src/trajopt_ifopt_utils.cpp#L68) and [lhs.setTimeLimit](https://github.com/tesseract-robotics/tesseract_planning/blob/0.35.0/motion_planners/trajopt_ifopt/src/trajopt_ifopt_utils.cpp#L83) in tesseract_planning (fixed by [this PR](https://github.com/gbionics/osqp-eigen/pull/221)).