### PR TITLE
Fix: getClosestFeasiblePoint silently discards the lower bound

### DIFF
--- a/trajopt_sco/src/modeling.cpp
+++ b/trajopt_sco/src/modeling.cpp
@@ -265,7 +265,7 @@ DblVec OptProb::getClosestFeasiblePoint(const DblVec& x, const double& delta)
   {
     // Force it a tiny bit inside the bounds
     y[i] = fmax(lower_bounds_[i] + delta, x[i]);
-    y[i] = fmin(upper_bounds_[i] - delta, x[i]);
+    y[i] = fmin(upper_bounds_[i] - delta, y[i]);
   }
   return y;
 }


### PR DESCRIPTION
The second statement overwrites the first and reads x[i] again, so the lower-bound clamp is thrown away.