### PR TITLE
Fix: getClosestFeasiblePoint returns a point outside narrow bounds

### DIFF
--- a/trajopt_sco/include/trajopt_sco/modeling.hpp
+++ b/trajopt_sco/include/trajopt_sco/modeling.hpp
@@ -235,9 +235,9 @@ public:
   DblVec getCentralFeasiblePoint(const DblVec& x);
   /**
    * @brief Pushes the input vector within joint limits by some amount in a repeatable fashion
-   * @param x Input vector. If it is already within joint limits, it will not be changed
+   * @param x Input vector. Values further than delta inside the joint limits are not changed
    * @param delta (Default = 1e-3) Amount that it is pushed within the joint limits. Pushing it exactly onto a limit can
-   * cause numerical problems
+   * cause numerical problems. Limits narrower than 2 * delta leave no room for this, and yield their midpoint
    * @return The input vector x with values modified to be within the joint limits
    */
   DblVec getClosestFeasiblePoint(const DblVec& x, const double& delta = 1e-3);

--- a/trajopt_sco/src/modeling.cpp
+++ b/trajopt_sco/src/modeling.cpp
@@ -1,5 +1,6 @@
 #include <trajopt_common/macros.h>
 TRAJOPT_IGNORE_WARNINGS_PUSH
+#include <algorithm>
 #include <boost/format.hpp>
 #include <cstdio>
 #include <sstream>
@@ -263,9 +264,10 @@ DblVec OptProb::getClosestFeasiblePoint(const DblVec& x, const double& delta)
   DblVec y(x.size());
   for (std::size_t i = 0; i < x.size(); i++)
   {
-    // Force it a tiny bit inside the bounds
-    y[i] = fmax(lower_bounds_[i] + delta, x[i]);
-    y[i] = fmin(upper_bounds_[i] - delta, y[i]);
+    // Force it a tiny bit inside the bounds. Bounds narrower than 2 * delta have no room for that, so the inset is
+    // capped at half their width, which places the point at their midpoint instead of outside them.
+    const double inset = std::min(delta, (upper_bounds_[i] - lower_bounds_[i]) / 2);
+    y[i] = std::min(std::max(x[i], lower_bounds_[i] + inset), upper_bounds_[i] - inset);
   }
   return y;
 }

--- a/trajopt_sco/test/CMakeLists.txt
+++ b/trajopt_sco/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_gtest()
 
-set(SCO_TEST_SOURCE unit.cpp solver-utils-unit.cpp)
+set(SCO_TEST_SOURCE unit.cpp modeling-unit.cpp solver-utils-unit.cpp)
 # These are parameterized over availableSolvers(), so they need at least one solver to be present
 if(GUROBI_FOUND
    OR osqp_FOUND

--- a/trajopt_sco/test/modeling-unit.cpp
+++ b/trajopt_sco/test/modeling-unit.cpp
@@ -1,0 +1,91 @@
+#include <trajopt_common/macros.h>
+TRAJOPT_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <vector>
+TRAJOPT_IGNORE_WARNINGS_POP
+
+#include <trajopt_sco/modeling.hpp>
+#include <trajopt_sco/solver_interface.hpp>
+
+using namespace sco;
+
+/** @brief Builds a problem whose variables have the given bounds */
+OptProb::Ptr problemWithBounds(const DblVec& lb, const DblVec& ub)
+{
+  auto prob = std::make_shared<OptProb>();
+  std::vector<std::string> names;
+  names.reserve(lb.size());
+  for (std::size_t i = 0; i < lb.size(); ++i)
+    names.push_back("x_" + std::to_string(i));
+  prob->createVariables(names, lb, ub);
+  return prob;
+}
+
+TEST(modeling, getClosestFeasiblePointClampsBothBounds)  // NOLINT
+{
+  const double delta = 1e-3;
+  auto prob = problemWithBounds(DblVec{ -1, -1, -1, -1 }, DblVec{ 1, 1, 1, 1 });
+
+  const DblVec y = prob->getClosestFeasiblePoint(DblVec{ 0.0, -2.0, 2.0, -1.0 }, delta);
+
+  EXPECT_DOUBLE_EQ(y[0], 0.0);           // interior, untouched
+  EXPECT_DOUBLE_EQ(y[1], -1.0 + delta);  // below the lower bound
+  EXPECT_DOUBLE_EQ(y[2], 1.0 - delta);   // above the upper bound
+  EXPECT_DOUBLE_EQ(y[3], -1.0 + delta);  // exactly on the lower bound
+}
+
+TEST(modeling, getClosestFeasiblePointInsetsFromBothBounds)  // NOLINT
+{
+  const double delta = 1e-3;
+  auto prob = problemWithBounds(DblVec{ -1, -1 }, DblVec{ 1, 1 });
+
+  // Inside the bounds but closer to them than delta
+  const DblVec y = prob->getClosestFeasiblePoint(DblVec{ -1.0 + (delta / 2), 1.0 - (delta / 2) }, delta);
+
+  EXPECT_DOUBLE_EQ(y[0], -1.0 + delta);
+  EXPECT_DOUBLE_EQ(y[1], 1.0 - delta);
+}
+
+TEST(modeling, getClosestFeasiblePointRespectsNarrowBounds)  // NOLINT
+{
+  const double delta = 1e-3;
+  // Bounds narrower than 2 * delta, and a zero width bound: there is no room to inset
+  const DblVec lb{ 0.0, 0.5 };
+  const DblVec ub{ delta, 0.5 };
+  auto prob = problemWithBounds(lb, ub);
+
+  for (const double x : { -1.0, 0.0, 0.25, 1.0 })
+  {
+    const DblVec y = prob->getClosestFeasiblePoint(DblVec{ x, x }, delta);
+    for (std::size_t i = 0; i < y.size(); ++i)
+    {
+      EXPECT_GE(y[i], lb[i]);
+      EXPECT_LE(y[i], ub[i]);
+      EXPECT_DOUBLE_EQ(y[i], (lb[i] + ub[i]) / 2);  // midpoint is as far inside as the bounds allow
+    }
+  }
+}
+
+TEST(modeling, getClosestFeasiblePointLeavesUnboundedVarsAlone)  // NOLINT
+{
+  const double inf = std::numeric_limits<double>::infinity();
+  auto prob = problemWithBounds(DblVec{ -inf, -inf }, DblVec{ inf, 1.0 });
+
+  const DblVec y = prob->getClosestFeasiblePoint(DblVec{ -1e9, -1e9 });
+
+  EXPECT_DOUBLE_EQ(y[0], -1e9);
+  EXPECT_DOUBLE_EQ(y[1], -1e9);
+}
+
+TEST(modeling, getClosestFeasiblePointIsIdempotent)  // NOLINT
+{
+  const double delta = 1e-3;
+  auto prob = problemWithBounds(DblVec{ -1, -1, 0.0 }, DblVec{ 1, 1, delta });
+
+  const DblVec once = prob->getClosestFeasiblePoint(DblVec{ -5.0, 5.0, 5.0 }, delta);
+  const DblVec twice = prob->getClosestFeasiblePoint(once, delta);
+
+  EXPECT_EQ(once, twice);
+}


### PR DESCRIPTION
Follow-up to #573.

The `delta` inset is applied unconditionally, so when a variable's bounds are narrower than `2 * delta` the result lands *outside* them — a "closest feasible point" that is infeasible. For zero-width bounds (`lb == ub`, e.g. a locked joint) the result is `ub - delta`, i.e. below the lower bound.

Capping the inset at half the bound width places the point at the midpoint instead, which is as far inside as the bounds allow:

```cpp
const double inset = std::min(delta, (upper_bounds_[i] - lower_bounds_[i]) / 2);
y[i] = std::min(std::max(x[i], lower_bounds_[i] + inset), upper_bounds_[i] - inset);
```

Behaviour is unchanged for any bounds wider than `2 * delta`. Writing it as a single expression also removes the two-assignment pattern that caused #573. `std::clamp` would read better, but it has a `lo <= hi` precondition that inverted bounds would turn into UB, whereas this form is total.

`modeling.cpp` had no direct unit test, so this adds `modeling-unit.cpp` covering both bounds, the inset, narrow and zero-width bounds, infinite bounds, and idempotence. Against current master only the narrow-bounds test fails; the other four pass and serve as regression guards for #573.