### PR TITLE
Fix: sco solver tests were compiled nowhere

### DIFF
--- a/trajopt_sco/test/CMakeLists.txt
+++ b/trajopt_sco/test/CMakeLists.txt
@@ -1,7 +1,11 @@
 find_gtest()
 
 set(SCO_TEST_SOURCE unit.cpp solver-utils-unit.cpp)
-if(HAVE_GUROBI OR HAVE_qpOASES)
+# These are parameterized over availableSolvers(), so they need at least one solver to be present
+if(GUROBI_FOUND
+   OR osqp_FOUND
+   OR qpOASES_FOUND
+   OR HAVE_BPMPD)
   list(
     APPEND
     SCO_TEST_SOURCE

--- a/trajopt_sco/test/small-problems-unit.cpp
+++ b/trajopt_sco/test/small-problems-unit.cpp
@@ -171,14 +171,4 @@ TEST_P(SQP, TP7)  // NOLINT
               GetParam());
 }
 
-auto getAvailableSolvers = []() {
-  std::vector<ModelType> solvers = availableSolvers();
-  auto it = std::find(solvers.begin(), solvers.end(), ModelType::OSQP);
-  if (it != solvers.end())
-  {
-    solvers.erase(it);
-  };
-  return solvers;
-};
-
-INSTANTIATE_TEST_CASE_P(AllSolvers, SQP, testing::ValuesIn(getAvailableSolvers()));
+INSTANTIATE_TEST_CASE_P(AllSolvers, SQP, testing::ValuesIn(availableSolvers()));

--- a/trajopt_sco/test/solver-interface-unit.cpp
+++ b/trajopt_sco/test/solver-interface-unit.cpp
@@ -1,8 +1,8 @@
 #include <trajopt_common/macros.h>
 TRAJOPT_IGNORE_WARNINGS_PUSH
-#include <cstdio>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <string>
 TRAJOPT_IGNORE_WARNINGS_POP
 
 #include <trajopt_sco/expr_ops.hpp>
@@ -36,9 +36,7 @@ TEST_P(SolverInterface, setup_problem)  // NOLINT
   VarVector vars;
   for (int i = 0; i < 3; ++i)
   {
-    char namebuf[5];
-    sprintf(namebuf, "v%i", i);
-    vars.push_back(solver->addVar(namebuf));
+    vars.push_back(solver->addVar("v" + std::to_string(i)));
   }
   solver->update();
 
@@ -79,15 +77,11 @@ TEST_P(SolverInterface, DISABLED_ExprMult_test1)  // NOLINT // QuadExpr not PSD
   VarVector vars;
   for (int i = 0; i < 3; ++i)
   {
-    char namebuf[5];
-    sprintf(namebuf, "v%i", i);
-    vars.push_back(solver->addVar(namebuf));
+    vars.push_back(solver->addVar("v" + std::to_string(i)));
   }
   for (int i = 3; i < 6; ++i)
   {
-    char namebuf[5];
-    sprintf(namebuf, "v%i", i);
-    vars.push_back(solver->addVar(namebuf));
+    vars.push_back(solver->addVar("v" + std::to_string(i)));
   }
   solver->update();
 
@@ -236,14 +230,4 @@ TEST_P(SolverInterface, ExprMult_test3)  // NOLINT
   EXPECT_NEAR(aff12.value(soln), answer, 1e-6);
 }
 
-auto getAvailableSolvers = []() {
-  std::vector<ModelType> solvers = availableSolvers();
-  auto it = std::find(solvers.begin(), solvers.end(), ModelType::OSQP);
-  if (it != solvers.end())
-  {
-    solvers.erase(it);
-  };
-  return solvers;
-};
-
-INSTANTIATE_TEST_CASE_P(AllSolvers, SolverInterface, testing::ValuesIn(getAvailableSolvers()));
+INSTANTIATE_TEST_CASE_P(AllSolvers, SolverInterface, testing::ValuesIn(availableSolvers()));


### PR DESCRIPTION
`trajopt_sco/test/CMakeLists.txt` gates `small-problems-unit.cpp` and `solver-interface-unit.cpp` on `if(HAVE_GUROBI OR HAVE_qpOASES)`. Neither name is a CMake variable: `GUROBI_FOUND` and `qpOASES_FOUND` are the variables `find_package` sets, and `HAVE_GUROBI`/`HAVE_QPOASES` (note the capitalisation) exist only as `target_compile_definitions` on the library. The condition has been false on every platform since #327, so both files have been compiled nowhere — the test binary contained 4 tests, all for `solver_utils`, and neither the optimizer nor `OptProb` was covered.

The gate now tests the `find_package` variables. Two follow-on changes were needed to make the files build and run:

- Both defined `getAvailableSolvers` at namespace scope, so compiling them together is a link error (multiple definition). That filter erased OSQP from the parameter list, which is what made the suites empty on the OSQP-only Windows build and prompted the gate in #327. Dropping it fixes the ODR clash and includes OSQP.
- `solver-interface-unit.cpp` used `char namebuf[5]` + `sprintf`, which clang-tidy rejects under `-warnings-as-errors`; replaced with `std::to_string`. Nothing else in either file trips clang-tidy.

The 2023 note in #327 that OSQP fails these tests no longer holds — locally all tests pass across OSQP, BPMPD and qpOASES (27 parameterized + the unparameterized ones). CI covers OSQP and qpOASES, so this is the real check.

`SolverInterface.DISABLED_ExprMult_test1` is left disabled, as it was.

Touches the same two lines of `test/CMakeLists.txt` as #574, so whichever merges second needs a one-line rebase.