### PR TITLE
Restore clear() on the thread-local FK transform caches

### DIFF
--- a/trajopt/include/trajopt/typedefs.hpp
+++ b/trajopt/include/trajopt/typedefs.hpp
@@ -48,6 +48,12 @@ public:
   }
 
 protected:
+  /**
+   * @brief Scratch map for forward kinematics results, shared by every calculator on the thread.
+   *
+   * It lives for the life of the thread, so a user that does not clear it before populating retains the union of
+   * every link set the thread has served. Clear it before each call that fills it.
+   */
   static thread_local tesseract::common::LinkIdTransformMap transforms_cache;  // NOLINT
 };
 
@@ -61,6 +67,12 @@ public:
   }
 
 protected:
+  /**
+   * @brief Scratch map for forward kinematics results, shared by every calculator on the thread.
+   *
+   * It lives for the life of the thread, so a user that does not clear it before populating retains the union of
+   * every link set the thread has served. Clear it before each call that fills it.
+   */
   static thread_local tesseract::common::LinkIdTransformMap transforms_cache;  // NOLINT
 };
 

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -99,8 +99,8 @@ VectorXd DynamicCartPoseErrCalculator::operator()(const VectorXd& dof_vals) cons
 {
   transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
-  const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
-  const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
+  const Isometry3d source_tf = transforms_cache.at(source_frame_) * source_frame_offset_;
+  const Isometry3d target_tf = transforms_cache.at(target_frame_) * target_frame_offset_;
 
   VectorXd err = error_function(target_tf, source_tf);
 
@@ -161,8 +161,8 @@ MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) cons
   // Finite-difference jacobian of the (optionally toleranced) Cartesian error.
   transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
-  const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
-  const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
+  const Isometry3d source_tf = transforms_cache.at(source_frame_) * source_frame_offset_;
+  const Isometry3d target_tf = transforms_cache.at(target_frame_) * target_frame_offset_;
 
   Eigen::MatrixXd jac0(indices_.size(), dof_vals.size());
   Eigen::VectorXd dof_vals_pert = dof_vals;
@@ -170,8 +170,8 @@ MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) cons
   {
     dof_vals_pert(i) = dof_vals(i) + epsilon_;
     manip_->calcFwdKin(transforms_cache, dof_vals_pert);
-    const Isometry3d source_tf_pert = transforms_cache[source_frame_] * source_frame_offset_;
-    const Isometry3d target_tf_pert = transforms_cache[target_frame_] * target_frame_offset_;
+    const Isometry3d source_tf_pert = transforms_cache.at(source_frame_) * source_frame_offset_;
+    const Isometry3d target_tf_pert = transforms_cache.at(target_frame_) * target_frame_offset_;
     VectorXd error_diff = tesseract::common::calcJacobianTransformErrorDiff(
         target_tf, target_tf_pert, source_tf, source_tf_pert, lower_tolerance_, upper_tolerance_);
 
@@ -253,8 +253,8 @@ VectorXd CartPoseErrCalculator::operator()(const VectorXd& dof_vals) const
 {
   transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
-  const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
-  const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
+  const Isometry3d source_tf = transforms_cache.at(source_frame_) * source_frame_offset_;
+  const Isometry3d target_tf = transforms_cache.at(target_frame_) * target_frame_offset_;
 
   VectorXd err = error_function_(target_tf, source_tf);
 
@@ -317,7 +317,7 @@ CartPoseJacCalculator::CartPoseJacCalculator(
                                   const Eigen::Isometry3d& source_tf,
                                   tesseract::common::LinkIdTransformMap& state_cache) -> VectorXd {
       manip_->calcFwdKin(state_cache, vals);
-      const Isometry3d perturbed_target_tf = state_cache[target_frame_] * target_frame_offset_;
+      const Isometry3d perturbed_target_tf = state_cache.at(target_frame_) * target_frame_offset_;
       VectorXd error_diff = tesseract::common::calcJacobianTransformErrorDiff(
           source_tf, target_tf, perturbed_target_tf, lower_tolerance_, upper_tolerance_);
 
@@ -335,7 +335,7 @@ CartPoseJacCalculator::CartPoseJacCalculator(
                                   const Eigen::Isometry3d& source_tf,
                                   tesseract::common::LinkIdTransformMap& state_cache) -> VectorXd {
       manip_->calcFwdKin(state_cache, vals);
-      const Isometry3d perturbed_source_tf = state_cache[source_frame_] * source_frame_offset_;
+      const Isometry3d perturbed_source_tf = state_cache.at(source_frame_) * source_frame_offset_;
       VectorXd error_diff = tesseract::common::calcJacobianTransformErrorDiff(
           target_tf, source_tf, perturbed_source_tf, lower_tolerance_, upper_tolerance_);
 
@@ -353,8 +353,8 @@ MatrixXd CartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
   // Finite-difference jacobian of the (optionally toleranced) Cartesian error.
   transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
-  const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
-  const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
+  const Isometry3d source_tf = transforms_cache.at(source_frame_) * source_frame_offset_;
+  const Isometry3d target_tf = transforms_cache.at(target_frame_) * target_frame_offset_;
 
   Eigen::MatrixXd jac0(indices_.size(), dof_vals.size());
   Eigen::VectorXd dof_vals_pert = dof_vals;
@@ -420,10 +420,10 @@ VectorXd CartVelErrCalculator::operator()(const VectorXd& dof_vals) const
   transforms_cache.clear();
 
   manip_->calcFwdKin(transforms_cache, dof_vals.topRows(n_dof));
-  Isometry3d pose0 = transforms_cache[link_id_] * tcp_;
+  Isometry3d pose0 = transforms_cache.at(link_id_) * tcp_;
 
   manip_->calcFwdKin(transforms_cache, dof_vals.bottomRows(n_dof));
-  Isometry3d pose1 = transforms_cache[link_id_] * tcp_;
+  Isometry3d pose1 = transforms_cache.at(link_id_) * tcp_;
 
   VectorXd out(6);
   out.topRows(3) = (pose1.translation() - pose0.translation() - Vector3d(limit_, limit_, limit_));

--- a/trajopt/src/kinematic_terms.cpp
+++ b/trajopt/src/kinematic_terms.cpp
@@ -97,6 +97,7 @@ DynamicCartPoseErrCalculator::DynamicCartPoseErrCalculator(
 
 VectorXd DynamicCartPoseErrCalculator::operator()(const VectorXd& dof_vals) const
 {
+  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -158,6 +159,7 @@ DynamicCartPoseJacCalculator::DynamicCartPoseJacCalculator(
 MatrixXd DynamicCartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
 {
   // Finite-difference jacobian of the (optionally toleranced) Cartesian error.
+  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -249,6 +251,7 @@ CartPoseErrCalculator::CartPoseErrCalculator(
 
 VectorXd CartPoseErrCalculator::operator()(const VectorXd& dof_vals) const
 {
+  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -348,6 +351,7 @@ CartPoseJacCalculator::CartPoseJacCalculator(
 MatrixXd CartPoseJacCalculator::operator()(const VectorXd& dof_vals) const
 {
   // Finite-difference jacobian of the (optionally toleranced) Cartesian error.
+  transforms_cache.clear();
   manip_->calcFwdKin(transforms_cache, dof_vals);
   const Isometry3d source_tf = transforms_cache[source_frame_] * source_frame_offset_;
   const Isometry3d target_tf = transforms_cache[target_frame_] * target_frame_offset_;
@@ -412,6 +416,8 @@ CartVelErrCalculator::CartVelErrCalculator(std::shared_ptr<const tesseract::kine
 VectorXd CartVelErrCalculator::operator()(const VectorXd& dof_vals) const
 {
   auto n_dof = static_cast<int>(manip_->numJoints());
+
+  transforms_cache.clear();
 
   manip_->calcFwdKin(transforms_cache, dof_vals.topRows(n_dof));
   Isometry3d pose0 = transforms_cache[link_id_] * tcp_;

--- a/trajopt/test/kinematic_costs_unit.cpp
+++ b/trajopt/test/kinematic_costs_unit.cpp
@@ -75,6 +75,7 @@ void checkJacobian(const sco::VectorOfVector& f,
     CONSOLE_BRIDGE_logError("Analytical:\n %s", toString(analytical).c_str());
   }
 }
+
 }  // namespace
 
 TEST_F(KinematicCostsTest, CartPoseJacCalculator)  // NOLINT
@@ -405,6 +406,59 @@ TEST_F(KinematicCostsTest, CartPoseCalculators_InvertedToleranceBandThrows)  // 
   EXPECT_THROW(DynamicCartPoseJacCalculator(
                    kin, source_frame, target_frame, source_frame_offset, target_frame_offset, indices, lower, upper),
                std::runtime_error);
+}
+
+TEST_F(KinematicCostsTest, TransformsCacheDoesNotAccumulateAcrossEnvironments)  // NOLINT
+{
+  CONSOLE_BRIDGE_logDebug("KinematicCostsTest, TransformsCacheDoesNotAccumulateAcrossEnvironments");
+
+  // The FK transform cache is a static thread_local shared by every calculator on the thread. Each operator() must
+  // clear it before populating, or it retains the union of every link set the thread has served. Two scene graphs are
+  // required to see this: two groups over one scene graph write identical key sets.
+  auto small_env = std::make_shared<Environment>();
+  {
+    const std::filesystem::path urdf_file(std::string(TRAJOPT_DATA_DIR) + "/boxbot.urdf");
+    const std::filesystem::path srdf_file(std::string(TRAJOPT_DATA_DIR) + "/boxbot.srdf");
+    const ResourceLocator::Ptr locator = std::make_shared<tesseract::common::GeneralResourceLocator>();
+    ASSERT_TRUE(small_env->init(urdf_file, srdf_file, locator));
+  }
+
+  const tesseract::kinematics::JointGroup::ConstPtr large_kin = env_->getJointGroup("right_arm");
+  const tesseract::kinematics::JointGroup::ConstPtr small_kin = small_env->getJointGroup("manipulator");
+  ASSERT_GT(large_kin->getLinkIds().size(), small_kin->getLinkIds().size());
+  ASSERT_GT(small_kin->numJoints(), 0);
+
+  // error_diff_function_ is handed the very map operator() just populated, which makes the cache observable without
+  // naming the protected static - a symbol the library does not export on Windows.
+  std::size_t large_observed{ 0 };
+  const std::string large_target_frame = "r_gripper_tool_frame";
+  CartPoseJacCalculator large_jac(large_kin, env_->getRootLinkId(), large_target_frame);
+  large_jac.error_diff_function_ = [&large_observed](const Eigen::VectorXd& /*dof_vals*/,
+                                                     const Eigen::Isometry3d& /*target_tf*/,
+                                                     const Eigen::Isometry3d& /*source_tf*/,
+                                                     tesseract::common::LinkIdTransformMap& state_cache) {
+    large_observed = state_cache.size();
+    return Eigen::VectorXd::Zero(6);
+  };
+
+  std::size_t small_observed{ 0 };
+  const std::string small_target_frame = "boxbot_link";
+  CartPoseJacCalculator small_jac(small_kin, small_env->getRootLinkId(), small_target_frame);
+  small_jac.error_diff_function_ = [&small_observed](const Eigen::VectorXd& /*dof_vals*/,
+                                                     const Eigen::Isometry3d& /*target_tf*/,
+                                                     const Eigen::Isometry3d& /*source_tf*/,
+                                                     tesseract::common::LinkIdTransformMap& state_cache) {
+    small_observed = state_cache.size();
+    return Eigen::VectorXd::Zero(6);
+  };
+
+  large_jac(Eigen::VectorXd::Zero(large_kin->numJoints()));
+  small_jac(Eigen::VectorXd::Zero(small_kin->numJoints()));
+
+  // calcFwdKin assigns every link of its group, so each call sees exactly its own group. The first assertion is what
+  // makes the second discriminating: the cache really did hold the larger set a moment earlier.
+  EXPECT_EQ(large_observed, large_kin->getLinkIds().size());
+  EXPECT_EQ(small_observed, small_kin->getLinkIds().size());
 }
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Follow-up to tesseract-robotics/tesseract_planning#734, where @Levi-Armstrong pointed out that a
`static thread_local` forward-kinematics scratch map that is never cleared holds the **union of every
link set the thread has served**. A planning server running many environments over one thread pool
grows it without bound. The same problem exists here.

`trajopt/src/kinematic_terms.cpp` lost five `clear()` calls in 43b3cbad (mine, merged before #554's
squash, so it is not part of 39e7cb00). Its reasoning covered correctness only: `calcFwdKin` does
overwrite every key it owns, which says nothing about keys left behind by a previous environment.
`transforms_cache` stayed `static thread_local` on `TrajOptVectorOfVector` / `TrajOptMatrixOfVector`,
so the residency is unbounded.

Four commits, each independently droppable:

1. **Restore the five clears.** One per call, not per FK evaluation — the finite-difference loops
   reuse the populated map deliberately, exactly as they did before 43b3cbad.
2. **Read the caches with `at()` instead of `operator[]`** (14 sites). `operator[]`
   default-constructs an `Isometry3d`, whose matrix is *uninitialised*, and multiplies that into the
   result with no diagnostic. Nothing validates the frames at construction — the constructors check
   only `isActiveLinkId`, which is false both for a static link and for a link absent from the group.
   The keys are present in practice because `JointGroup::calcFwdKin` assigns every scene link on
   every call, but that is precisely the assumption #734 was right to push on; `at()` makes the code
   fail loudly instead of returning a garbage pose. This is a behaviour change on malformed input,
   hence its own commit.
3. **Regression test.** `KinematicCostsTest.TransformsCacheDoesNotAccumulateAcrossEnvironments`
   evaluates a `CartPoseJacCalculator` against the 89-link `arm_around_table` group and then the
   7-link `boxbot` one on the same thread, and asserts each call sees only its own group's links.
   Two *scene graphs* are needed — two groups over one graph write identical key sets, so the union
   never grows. Verified to fail when the clear is removed again: the second call then sees 95 links
   rather than 7.

   It observes the cache through `error_diff_function_`, which `operator()` hands the map it has
   just populated. That is deliberate — see the Windows note below.
4. **Document the contract** on the two declarations, which carried no comment at all.

### On the alternative

Moving the cache into the five calculators as a `mutable` member — the shape used in 184926b4 for
`CollisionEvaluator`, and in `trajopt_ifopt/costs/squared_cost.h` — would keep the allocation saving
and bound residency. I rejected it: `static thread_local` stays correct if a calculator instance is
ever shared across threads, and a `mutable` member does not, with nothing enforcing the invariant.
A per-instance per-thread cache keeps both properties but needs `omp_get_thread_num()`, and `trajopt`
core does not link OpenMP; its footprint is also wrong by roughly two orders of magnitude. Happy to
revisit if you prefer the member form.

To be precise about what the fix buys: `clear()` deallocates the nodes but keeps the bucket array, so
node storage returns to the current link set while the bucket count stays at its per-thread
high-water mark. That is 8 B/bucket against ~152 B/node, so the residual is the small part — but the
map does not return to nothing.

### One Windows observation

The first version of this test derived from `TrajOptVectorOfVector` to read `transforms_cache`
directly. That links on Linux through default visibility, but `conda-win` rejected it:

```
error LNK2019: unresolved external symbol
  "protected: static ... trajopt::TrajOptVectorOfVector::transforms_cache"
```

Neither base class nor the member carries `TRAJOPT_API`, so the symbol is not exported from
`trajopt.dll`. All sixteen classes deriving from those two bases live inside the library, so nothing
is broken today — but the member is `protected` in a public header, which reads as an invitation to
derive, and any out-of-DLL deriver would hit the same wall. I did not add the export: widening the
Windows ABI to make a test link seemed the wrong trade in this PR. Instead the test observes the map
through `error_diff_function_`, which needs no exported symbol. Say the word if you would rather
have the export.

### Out of scope, flagged only

- **Constructor validation.** `JointGroup::hasLinkId` exists and is unused here; validating the
  frames up front would give a better message than a bare `std::out_of_range`. It is a design call
  across five classes, so not in this PR.
- **`trajopt_ifopt` has a redundant `calcFwdKin`.** `CartPosConstraint::calcJacobianBlock` (:332) and
  `CartLineConstraint::calcJacobianBlock` (:195) call `calcFwdKin` a second time with the identical
  `joint_vals`, recomputing a cache the top of the same function already populated; in the line
  constraint four locals then shadow the outer ones with identical values. Not a residency problem —
  both functions do clear — just wasted work. Untouched here.
- **`trajopt_ifopt` reads its caches with `operator[]`** at 7 sites, the same hazard commit 2 removes
  from `kinematic_terms.cpp`. Left out to keep commit 2 droppable; happy to add it here or in a
  separate PR.

Tests: `trajopt`, `trajopt_sco`, `trajopt_ifopt`, `trajopt_sqp`, `trajopt_common` all green (189
tests, 0 failures).
