### PR TITLE
Move ccache setup into colcon-action@v15

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -10,6 +10,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   clang_format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -10,6 +10,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cmake_lang:
     runs-on: ubuntu-22.04

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,6 +10,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   conda-win:
     runs-on: windows-2022

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -75,9 +75,9 @@ jobs:
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}/lib" >> "$GITHUB_ENV"
         echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}" >> "$GITHUB_ENV"
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v14
+      uses: tesseract-robotics/colcon-action@v15
       with:
-        ccache-prefix: ci-mac-build-${{ matrix.config.name }}
+        ccache-prefix: ci-mac-build-${{ matrix.config.arch }}
         vcs-file: .github/workflows/windows_dependencies.repos
         rosdep-enabled: false
         upstream-args: >-

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -16,6 +16,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   VCPKG_PKGS: >- 
     boost-dll boost-program-options boost-stacktrace

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -8,6 +8,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   get-tag:
     # Pre-job to fetch the latest tag

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -63,7 +63,7 @@ jobs:
           apt install -y clang-tidy
 
       - name: Build and test
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash
           ccache-enabled: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   get-tag:
     # Pre-job to fetch the latest tag

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,6 @@ jobs:
     container:
       image: ghcr.io/tesseract-robotics/tesseract:${{ matrix.distro }}-${{ needs.get-tag.outputs.major }}.${{ needs.get-tag.outputs.minor }}
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
 
@@ -60,10 +59,10 @@ jobs:
           path: target_ws/src
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: ubuntu-${{ matrix.distro }}
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Debug -DTRAJOPT_ENABLE_TESTING=ON -DTRAJOPT_ENABLE_BENCHMARKING=ON -DTRAJOPT_ENABLE_RUN_BENCHMARKING=OFF

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -27,7 +27,6 @@ jobs:
     container:
       image: ghcr.io/tesseract-robotics/tesseract:${{ matrix.distro }}-master
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -54,10 +53,10 @@ jobs:
           apt install -y clang-tidy-17 libomp-17-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: unstable-${{ matrix.distro }}
           rosdep-install-args: -iry --skip-keys=libomp-dev
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}-unstable

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,9 +51,9 @@ jobs:
         echo "CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE\vcpkg\installed\x64-windows-release" >> "$GITHUB_ENV"
 
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v14
+      uses: tesseract-robotics/colcon-action@v15
       with:
-        ccache-prefix: ${{ matrix.distro }}
+        ccache-prefix: ${{ matrix.os }}
         vcs-file: .github/workflows/windows_dependencies.repos
         upstream-args: --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF
         target-path: target_ws/src

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.os }}


### PR DESCRIPTION
Third in the series that moves ccache wiring out of the workflows and into
[colcon-action](https://github.com/tesseract-robotics/colcon-action); tesseract#1351 and
tesseract_planning#769 were the first two. Fixes tesseract#1345 and tesseract#1346 for this repo.

### What was wrong

**`CCACHE_DIR` pointed where nothing was cached.** `ubuntu.yml` and `unstable.yml` set it in the
container `env:` map as a literal `$GITHUB_WORKSPACE/...`. GitHub never runs a shell over that map,
so the variable stayed unexpanded. On noble ccache expands `$VAR` in its own config (4.9+) and it
happened to work; on jammy (4.5.1) it did not, and the directory handed to `actions/cache` was not
the directory ccache filled. `@v15` resolves the path by asking ccache, so the line is deleted
rather than corrected.

**Two `ccache-prefix` values named a matrix key their matrix does not define.** An undefined
`matrix.x` is not an error in Actions — it expands to the empty string:

| file | prefix | matrix defines | effect |
| --- | --- | --- | --- |
| `mac.yml` | `ci-mac-build-${{ matrix.config.name }}` | `config.arch`, not `config.name` | **live**: `x64` and `arm64` shared one entry and evicted each other every run |
| `windows.yml` | `${{ matrix.distro }}` | `os`, not `distro` | latent: one leg, so nothing to collide with yet |

**`ubuntu` and `unstable` shared one restore namespace.** `@v15`'s restore key is
`<prefix>-<runner.os>-ccache-<github.job>-`, and the job id is `ci` in both, so an identical
`${{ matrix.distro }}` prefix put two different build configurations — a release-image build and a
`-master`-image clang-tidy build — in one `ccache-maxsize` cap. They are now `ubuntu-` and
`unstable-` prefixed.

`package_debian.yml` is bumped in its own commit. `ccache-enabled: false` opts out of ccache, not out
of the action, and v14→v15 also carries `$SUDO` handling and `action_repository` changes.

Nothing else to strip here: unlike the first two repos, no workflow in this one passes
`-DCMAKE_CXX_COMPILER_LAUNCHER=ccache` in its CMake arguments, and none has a hand-rolled
`Configure ccache` or `Report ccache statistics` step.

### Every workflow is cold exactly once

`@v14`'s restore key used lowercase `linux`; `@v15` uses `${{ runner.os }}`, which is `Linux`. No
`@v14` entry can prefix-match a `@v15` restore key, so every workflow here is cold on its first run
after this merges regardless of the prefix renames. One cold run, then normal.

### Measured

Two consecutive runs, cold then warm, on this branch. The figure is the **`Build and Tests` step**,
not the run — `vcpkg build` is a separate step and is excluded, which matters here (see below).

| leg | cold | warm | warm hits |
| --- | --- | --- | --- |
| unstable jammy / noble | 20.6 / 4.9 m | **19.0 / 3.5 m** | 228/228 (100%) · 206/223 (92.4%) |
| mac x64 / arm64 | 33.4 / 15.6 m | **6.9 / 3.4 m** | 435/456 (95.4%) both legs |
| windows | 16.2 m | **4.0 m** | 375/375 (100%) |
| ubuntu jammy / noble | 0.8 / 0.8 m | 0.8 / 0.6 m | 67/67 · 65/66 |

`Unstable`'s jammy leg gains least because it is the clang-tidy leg, and ccache caches compilation,
not the analyzer pass. `Ubuntu` fails at configure, so its numbers are a 66-call sample and prove only
that the wiring is correct — see below.

A warm hit rate below 100% is expected on noble and macOS and is not a defect. Newer CMake runs its
`try_compile` probes from `CMakeFiles/CMakeScratch/TryCompile-<random>/`, and a randomised path is
part of ccache's hash, so those calls can never hit. jammy reads 100% only because cmake 3.22 uses a
stable path. Likewise Windows' `Uncacheable calls: 75 / 450` is invariant to cache state — identical
on the cold and the warm run — because those are link steps.

`Cache size (GB)` peaked at 0.10 / 1.00, so the `1G` cap has ample headroom here.

**Windows' 12 minutes are ccache's alone**: the vcpkg cache key was byte-identical across both runs
and hit on both (`…-vcpkg-32db901f…`), so nothing of that delta belongs to vcpkg. macOS is the
opposite case and worth stating plainly: its vcpkg cache *missed* on the cold run and rebuilt
(43.5 m x64 / 24.1 m arm64), then hit on the warm one. That is why the table quotes the build step
rather than the run — the run-level drop on macOS is mostly vcpkg, and none of it is claimed here.

### Pre-existing failures, none of them caused by this PR

Censused on `master` at 33e81d81 before the first edit. `Unstable`, `Mac OSX`, `Windows`, `Conda`
and `Docker` are all green there; one workflow is not:

- **`Ubuntu` is red on `master` itself.** It pins the released image tag
  `tesseract:<distro>-<major>.<minor>`, whose tesseract predates
  `tesseract-config.cmake`'s `common_test_suite` component, so `trajopt_common` fails at **CMake
  configure**: `failed to find required component common_test_suite for package tesseract`. It will
  stay red until a new tesseract release is tagged. `Package-Debian-Build` pins a release tag too and
  fails the same way.

  Worth stating precisely, because it changes how this PR is read: the failure is early enough that
  almost nothing is compiled. `trajopt_common` exits after 0.58 s, `osqp` and `qpoases` are aborted
  partway, and the run summary is `0 packages finished` — 66 cacheable calls in total, filling 0.18 %
  of the cache. `Ubuntu`'s restore, save, prefix and environment signals are all readable and all
  correct; its hit rate and build time are not meaningful on that sample. The verdict for this PR is
  therefore taken from `Unstable`, `Mac OSX` and `Windows`, which are green.

### Verification

Worked in two phases, because the two changes in this PR are verified by opposite actions — ccache
needs two runs that both complete, cancellation needs a push that interrupts one.

**Phase A — ccache.** Two consecutive runs, cold then warm, the second obtained by re-running the
first rather than by pushing a throwaway commit — attempt 2 prefix-matches attempt 1's key, so the
branch stays at exactly what will merge. On every workflow: `CCACHE_DIR` resolved by the action to a
real absolute path (`/__w/trajopt/trajopt/.ccache` in the containers), `CCACHE_MAXSIZE: 1G`,
`Statistics zeroed` after the restore, both `CMAKE_C_` and `CMAKE_CXX_COMPILER_LAUNCHER` exported, a
real `Cache saved with key:`, then on the second run `Cache restored from key:` naming the first
run's key. **Swept all 14 jobs across both attempts: zero `::warning::` from the action, zero
`Path Validation Error` in any post-job cleanup.**

The renamed prefixes are visible in the keys and confirm the fixes did what they claim:
`ci-mac-build-x64-…` and `ci-mac-build-arm64-…` now restore separately where they previously shared
one entry, `windows-2022-Windows-ccache-ci-…` replaces an empty prefix, and `ubuntu-` and `unstable-`
no longer collide.

Two things `@v15` promises that a normal run does not exercise were confirmed incidentally, because
`Ubuntu` fails: **the cache is saved after a failed build** (`Cache saved with key: …-1` on both legs
of a run whose build step failed), and it is restored again on the next run (`…-1` restored, `…-2`
saved).

**Phase B — concurrency.** All 9 workflows take the block; all 9 are schema-valid, so nothing is
excluded. Pushed, waited for the matrix to go live, pushed an empty commit, then force-pushed to drop
it — two independent observations. First: **7 of 8 in-flight runs cancelled**, with `CMake-Format`,
which had already finished, staying `success`. Second: **6 of 8 cancelled**, with both format checks
already finished and staying `success`. Cancellation supersedes only what is still live, which is the
behaviour that makes this safe on push and release.

**`package_debian.yml`** was verified by `workflow_dispatch` on a fork, since no pull request can
trigger a tag-push workflow. On both legs the action's `Configure ccache` step reports
`outcome=skipped` under `ccache-enabled: false` — as do `Restore cache`, `Zero ccache statistics`,
`Report ccache statistics` and `Save cache` — with no warnings. The run then fails at the same
pre-existing `common_test_suite` error as `Ubuntu`.
