### PR TITLE
Harden the trajopt_ifopt FK cache reads and drop a duplicate calcFwdKin

### DIFF
--- a/trajopt_ifopt/src/constraints/cartesian_line_constraint.cpp
+++ b/trajopt_ifopt/src/constraints/cartesian_line_constraint.cpp
@@ -100,9 +100,9 @@ CartLineConstraint::CartLineConstraint(CartLineInfo info,
                                 const Eigen::Isometry3d& source_tf,
                                 tesseract::common::LinkIdTransformMap& transforms_cache) -> Eigen::VectorXd {
     info_.manip->calcFwdKin(transforms_cache, vals);
-    const Eigen::Isometry3d perturbed_source_tf = transforms_cache[info_.source_frame] * info_.source_frame_offset;
-    const Eigen::Isometry3d target_tf1 = transforms_cache[info_.target_frame] * info_.target_frame_offset1;
-    const Eigen::Isometry3d target_tf2 = transforms_cache[info_.target_frame] * info_.target_frame_offset2;
+    const Eigen::Isometry3d perturbed_source_tf = transforms_cache.at(info_.source_frame) * info_.source_frame_offset;
+    const Eigen::Isometry3d target_tf1 = transforms_cache.at(info_.target_frame) * info_.target_frame_offset1;
+    const Eigen::Isometry3d target_tf2 = transforms_cache.at(info_.target_frame) * info_.target_frame_offset2;
 
     // For Jacobian Calc, we need the inverse of the nearest point, D, to new Pose, C, on the constraint line AB
     const Eigen::Isometry3d perturbed_target_tf = getLinePoint(perturbed_source_tf, target_tf1, target_tf2);
@@ -122,9 +122,9 @@ Eigen::VectorXd CartLineConstraint::calcValues(const Eigen::Ref<const Eigen::Vec
 {
   transforms_cache_.clear();
   info_.manip->calcFwdKin(transforms_cache_, joint_vals);
-  const Eigen::Isometry3d source_tf = transforms_cache_[info_.source_frame] * info_.source_frame_offset;
-  const Eigen::Isometry3d target_tf1 = transforms_cache_[info_.target_frame] * info_.target_frame_offset1;
-  const Eigen::Isometry3d target_tf2 = transforms_cache_[info_.target_frame] * info_.target_frame_offset2;
+  const Eigen::Isometry3d source_tf = transforms_cache_.at(info_.source_frame) * info_.source_frame_offset;
+  const Eigen::Isometry3d target_tf1 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset1;
+  const Eigen::Isometry3d target_tf2 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset2;
 
   // For Jacobian Calc, we need the inverse of the nearest point, D, to new Pose, C, on the constraint line AB
   const Eigen::Isometry3d target_tf = getLinePoint(source_tf, target_tf1, target_tf2);
@@ -158,9 +158,9 @@ void CartLineConstraint::calcJacobianBlock(Jacobian& jac_block,
 {
   transforms_cache_.clear();
   info_.manip->calcFwdKin(transforms_cache_, joint_vals);
-  const Eigen::Isometry3d source_tf = transforms_cache_[info_.source_frame] * info_.source_frame_offset;
-  const Eigen::Isometry3d target_tf1 = transforms_cache_[info_.target_frame] * info_.target_frame_offset1;
-  const Eigen::Isometry3d target_tf2 = transforms_cache_[info_.target_frame] * info_.target_frame_offset2;
+  const Eigen::Isometry3d source_tf = transforms_cache_.at(info_.source_frame) * info_.source_frame_offset;
+  const Eigen::Isometry3d target_tf1 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset1;
+  const Eigen::Isometry3d target_tf2 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset2;
 
   // For Jacobian Calc, we need the inverse of the nearest point, D, to new Pose, C, on the constraint line AB
   const Eigen::Isometry3d target_tf = getLinePoint(source_tf, target_tf1, target_tf2);
@@ -193,9 +193,9 @@ void CartLineConstraint::calcJacobianBlock(Jacobian& jac_block,
   {
     // Reserve enough room in the sparse matrix
     info_.manip->calcFwdKin(transforms_cache_, joint_vals);
-    const Eigen::Isometry3d source_tf = transforms_cache_[info_.source_frame] * info_.source_frame_offset;
-    const Eigen::Isometry3d target_tf1 = transforms_cache_[info_.target_frame] * info_.target_frame_offset1;
-    const Eigen::Isometry3d target_tf2 = transforms_cache_[info_.target_frame] * info_.target_frame_offset2;
+    const Eigen::Isometry3d source_tf = transforms_cache_.at(info_.source_frame) * info_.source_frame_offset;
+    const Eigen::Isometry3d target_tf1 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset1;
+    const Eigen::Isometry3d target_tf2 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset2;
 
     // For Jacobian Calc, we need the inverse of the nearest point, D, to new Pose, C, on the constraint line AB
     const Eigen::Isometry3d target_tf = getLinePoint(source_tf, target_tf1, target_tf2);

--- a/trajopt_ifopt/src/constraints/cartesian_line_constraint.cpp
+++ b/trajopt_ifopt/src/constraints/cartesian_line_constraint.cpp
@@ -191,15 +191,6 @@ void CartLineConstraint::calcJacobianBlock(Jacobian& jac_block,
   }
   else
   {
-    // Reserve enough room in the sparse matrix
-    info_.manip->calcFwdKin(transforms_cache_, joint_vals);
-    const Eigen::Isometry3d source_tf = transforms_cache_.at(info_.source_frame) * info_.source_frame_offset;
-    const Eigen::Isometry3d target_tf1 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset1;
-    const Eigen::Isometry3d target_tf2 = transforms_cache_.at(info_.target_frame) * info_.target_frame_offset2;
-
-    // For Jacobian Calc, we need the inverse of the nearest point, D, to new Pose, C, on the constraint line AB
-    const Eigen::Isometry3d target_tf = getLinePoint(source_tf, target_tf1, target_tf2);
-
     Eigen::MatrixXd jac0 =
         info_.manip->calcJacobian(joint_vals, info_.source_frame, info_.source_frame_offset.translation());
     tesseract::common::jacobianChangeBase(jac0, target_tf.inverse());

--- a/trajopt_ifopt/src/constraints/cartesian_position_constraint.cpp
+++ b/trajopt_ifopt/src/constraints/cartesian_position_constraint.cpp
@@ -329,12 +329,11 @@ void CartPosConstraint::calcJacobianBlock(Jacobian& jac_block,
     // that is required to be modified per the paper.
 
     // Calculate the jacobian
-    manip_->calcFwdKin(transforms_cache_, joint_vals);
     Eigen::MatrixXd jac0;
     if (type_ == Type::kTargetActive)
     {
       jac0 = manip_->calcJacobian(joint_vals, target_frame_, target_frame_offset_.translation());
-      tesseract::common::jacobianChangeBase(jac0, (transforms_cache_.at(source_frame_) * source_frame_offset_).inverse());
+      tesseract::common::jacobianChangeBase(jac0, source_tf.inverse());
 
       for (int c = 0; c < jac0.cols(); ++c)
       {
@@ -347,7 +346,7 @@ void CartPosConstraint::calcJacobianBlock(Jacobian& jac_block,
     else
     {
       jac0 = manip_->calcJacobian(joint_vals, source_frame_, source_frame_offset_.translation());
-      tesseract::common::jacobianChangeBase(jac0, (transforms_cache_.at(target_frame_) * target_frame_offset_).inverse());
+      tesseract::common::jacobianChangeBase(jac0, target_tf.inverse());
 
       for (int c = 0; c < jac0.cols(); ++c)
       {

--- a/trajopt_ifopt/src/constraints/cartesian_position_constraint.cpp
+++ b/trajopt_ifopt/src/constraints/cartesian_position_constraint.cpp
@@ -156,7 +156,7 @@ CartPosConstraint::CartPosConstraint(std::shared_ptr<const Var> position_var,
                                     const Eigen::Isometry3d& source_tf,
                                     tesseract::common::LinkIdTransformMap& transforms_cache) -> Eigen::VectorXd {
         manip_->calcFwdKin(transforms_cache, vals);
-        const Eigen::Isometry3d perturbed_target_tf = transforms_cache[target_frame_] * target_frame_offset_;
+        const Eigen::Isometry3d perturbed_target_tf = transforms_cache.at(target_frame_) * target_frame_offset_;
         Eigen::VectorXd error_diff =
             tesseract::common::calcJacobianTransformErrorDiff(source_tf, target_tf, perturbed_target_tf);
 
@@ -189,7 +189,7 @@ CartPosConstraint::CartPosConstraint(std::shared_ptr<const Var> position_var,
                                     const Eigen::Isometry3d& source_tf,
                                     tesseract::common::LinkIdTransformMap& transforms_cache) -> Eigen::VectorXd {
         manip_->calcFwdKin(transforms_cache, vals);
-        const Eigen::Isometry3d perturbed_source_tf = transforms_cache[source_frame_] * source_frame_offset_;
+        const Eigen::Isometry3d perturbed_source_tf = transforms_cache.at(source_frame_) * source_frame_offset_;
         Eigen::VectorXd error_diff =
             tesseract::common::calcJacobianTransformErrorDiff(target_tf, source_tf, perturbed_source_tf);
 
@@ -222,8 +222,8 @@ CartPosConstraint::CartPosConstraint(std::shared_ptr<const Var> position_var,
                                     tesseract::common::LinkIdTransformMap& transforms_cache) -> Eigen::VectorXd {
         /** @todo This is different from legacy kinematic_terms */
         manip_->calcFwdKin(transforms_cache, vals);
-        const Eigen::Isometry3d perturbed_source_tf = transforms_cache[source_frame_] * source_frame_offset_;
-        const Eigen::Isometry3d perturbed_target_tf = transforms_cache[target_frame_] * target_frame_offset_;
+        const Eigen::Isometry3d perturbed_source_tf = transforms_cache.at(source_frame_) * source_frame_offset_;
+        const Eigen::Isometry3d perturbed_target_tf = transforms_cache.at(target_frame_) * target_frame_offset_;
         Eigen::VectorXd error_diff = tesseract::common::calcJacobianTransformErrorDiff(
             target_tf, perturbed_target_tf, source_tf, perturbed_source_tf);
 
@@ -264,8 +264,8 @@ Eigen::VectorXd CartPosConstraint::calcValues(const Eigen::Ref<const Eigen::Vect
 {
   transforms_cache_.clear();
   manip_->calcFwdKin(transforms_cache_, joint_vals);
-  const Eigen::Isometry3d source_tf = transforms_cache_[source_frame_] * source_frame_offset_;
-  const Eigen::Isometry3d target_tf = transforms_cache_[target_frame_] * target_frame_offset_;
+  const Eigen::Isometry3d source_tf = transforms_cache_.at(source_frame_) * source_frame_offset_;
+  const Eigen::Isometry3d target_tf = transforms_cache_.at(target_frame_) * target_frame_offset_;
 
   const Eigen::VectorXd err = error_function_(target_tf, source_tf);
 
@@ -283,8 +283,8 @@ void CartPosConstraint::calcJacobianBlock(Jacobian& jac_block,
 {
   transforms_cache_.clear();
   manip_->calcFwdKin(transforms_cache_, joint_vals);
-  const Eigen::Isometry3d source_tf = transforms_cache_[source_frame_] * source_frame_offset_;
-  const Eigen::Isometry3d target_tf = transforms_cache_[target_frame_] * target_frame_offset_;
+  const Eigen::Isometry3d source_tf = transforms_cache_.at(source_frame_) * source_frame_offset_;
+  const Eigen::Isometry3d target_tf = transforms_cache_.at(target_frame_) * target_frame_offset_;
 
   constexpr double eps{ 1e-5 };
   if (use_numeric_differentiation || type_ == Type::kBothActive)
@@ -334,7 +334,7 @@ void CartPosConstraint::calcJacobianBlock(Jacobian& jac_block,
     if (type_ == Type::kTargetActive)
     {
       jac0 = manip_->calcJacobian(joint_vals, target_frame_, target_frame_offset_.translation());
-      tesseract::common::jacobianChangeBase(jac0, (transforms_cache_[source_frame_] * source_frame_offset_).inverse());
+      tesseract::common::jacobianChangeBase(jac0, (transforms_cache_.at(source_frame_) * source_frame_offset_).inverse());
 
       for (int c = 0; c < jac0.cols(); ++c)
       {
@@ -347,7 +347,7 @@ void CartPosConstraint::calcJacobianBlock(Jacobian& jac_block,
     else
     {
       jac0 = manip_->calcJacobian(joint_vals, source_frame_, source_frame_offset_.translation());
-      tesseract::common::jacobianChangeBase(jac0, (transforms_cache_[target_frame_] * target_frame_offset_).inverse());
+      tesseract::common::jacobianChangeBase(jac0, (transforms_cache_.at(target_frame_) * target_frame_offset_).inverse());
 
       for (int c = 0; c < jac0.cols(); ++c)
       {
@@ -395,7 +395,7 @@ Eigen::Isometry3d CartPosConstraint::getCurrentPose() const
   transforms_cache_.clear();
   manip_->calcFwdKin(transforms_cache_, position_var_->value());
 
-  return transforms_cache_[source_frame_] * source_frame_offset_;
+  return transforms_cache_.at(source_frame_) * source_frame_offset_;
 }
 
 }  // namespace trajopt_ifopt

--- a/trajopt_ifopt/src/constraints/collision/continuous_collision_evaluators.cpp
+++ b/trajopt_ifopt/src/constraints/collision/continuous_collision_evaluators.cpp
@@ -182,7 +182,7 @@ void LVSContinuousCollisionEvaluator::calcCollisionsHelper(tesseract::collision:
   {
     get_state_fn_(transforms_cache0, dof_vals0);
     for (const auto& link_id : diff_active_link_ids_)
-      contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0[link_id]);
+      contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0.at(link_id));
   }
 
   // Create filter
@@ -223,7 +223,8 @@ void LVSContinuousCollisionEvaluator::calcCollisionsHelper(tesseract::collision:
       get_state_fn_(transforms_cache1, subtraj.row(i + 1));
 
       for (const auto& link_id : manip_active_link_ids_)
-        contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0[link_id], transforms_cache1[link_id]);
+        contact_manager_->setCollisionObjectsTransform(
+            link_id, transforms_cache0.at(link_id), transforms_cache1.at(link_id));
 
       contact_manager_->contactTest(contacts, collision_check_config_.contact_request);
       if (!contacts.empty())
@@ -239,7 +240,8 @@ void LVSContinuousCollisionEvaluator::calcCollisionsHelper(tesseract::collision:
     get_state_fn_(transforms_cache0, dof_vals0);
     get_state_fn_(transforms_cache1, dof_vals1);
     for (const auto& link_id : manip_active_link_ids_)
-      contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0[link_id], transforms_cache1[link_id]);
+      contact_manager_->setCollisionObjectsTransform(
+          link_id, transforms_cache0.at(link_id), transforms_cache1.at(link_id));
 
     contact_manager_->contactTest(dist_results, collision_check_config_.contact_request);
 
@@ -396,7 +398,7 @@ void LVSDiscreteCollisionEvaluator::calcCollisionsHelper(tesseract::collision::C
   {
     get_state_fn_(transforms_cache0, dof_vals0);
     for (const auto& link_id : diff_active_link_ids_)
-      contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0[link_id]);
+      contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0.at(link_id));
   }
 
   // Create filter
@@ -444,7 +446,7 @@ void LVSDiscreteCollisionEvaluator::calcCollisionsHelper(tesseract::collision::C
     get_state_fn_(transforms_cache0, subtraj.row(i));
 
     for (const auto& link_id : manip_active_link_ids_)
-      contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0[link_id]);
+      contact_manager_->setCollisionObjectsTransform(link_id, transforms_cache0.at(link_id));
 
     contact_manager_->contactTest(contacts, collision_check_config_.contact_request);
 


### PR DESCRIPTION
Follow-up to #579, which restored the `clear()` calls on the thread-local FK transform caches in
`trajopt`. That PR's description flagged two things in `trajopt_ifopt` as out of scope. This is them.
Two commits, independent — the second can be dropped without touching the first.

### 1. Read the caches with `at()` instead of `operator[]` (30 sites)

Same change #579 made in `kinematic_terms.cpp`, applied to the three files in `trajopt_ifopt` that
read an FK cache: `cartesian_position_constraint.cpp` (11), `cartesian_line_constraint.cpp` (12) and
`continuous_collision_evaluators.cpp` (7).

The failure mode is worse than I assumed when I wrote #579. On a miss `operator[]` default-constructs
the mapped value, and a default-constructed `Eigen::Isometry3d` is **not identity — it is
uninitialised**. Filling the memory with a known byte pattern first and printing what comes back:

```
-2.53017e-98 -2.53017e-98 -2.53017e-98 -2.53017e-98
-2.53017e-98 -2.53017e-98 -2.53017e-98 -2.53017e-98
-2.53017e-98 -2.53017e-98 -2.53017e-98 -2.53017e-98
           0            0            0            1
```

Only the bottom row is set. So a miss would not quietly place a frame at the origin; it would
multiply garbage into a constraint value or a jacobian column, nondeterministically, with nothing
raised anywhere. That surfaces as an optimiser that will not converge, and it would be hunted in the
solver rather than in a map lookup.

**To be clear: no site can miss today.** `CartPosConstraint` and `CartLineInfo` both reject unknown
frames in their constructors, the collision evaluators key off the group's own active link ids, and
both state solvers assign every scene link unconditionally. This is a guard, not a bug fix. The
reason I still think it is worth taking is that the invariant is **non-local** — it lives in the
state solver, invisible from the call site — and it has been broken before: the `insert_or_assign`
pre-pass in `OFKTStateSolver::getLinkTransforms` exists because `update()` is conditional.

### 2. Drop the duplicate `calcFwdKin` from the analytic jacobian branches

Both `calcJacobianBlock`s call `calcFwdKin` at the top and then again with the same `joint_vals` in
the analytic branch. Nothing invalidates the cache in between — the perturbation loop that would is
in the mutually exclusive numeric branch — so the second call recomputes a map that is already
correct. In the line constraint it is followed by four locals shadowing the outer ones with identical
values, plus a comment describing neither.

Two caveats, since they decide how much this is worth:

- **It is dead code.** The branch runs only when `use_numeric_differentiation` is `false`, and
  nothing sets it. So this saves nothing at runtime today.
- **No test reaches it**, which I established the hard way: a deliberately wrong substitution in that
  branch passed the whole suite. So I verified equivalence rather than correctness — dumping both
  analytic paths (`kTargetActive`, `kSourceActive`, and the line constraint) at 17 significant digits
  across 7 dof, before and after. Bit-identical. A sentinel perturbation confirmed the probe was
  sensitive and the binary really rebuilt.

I deliberately did **not** add a test asserting the analytic jacobian matches the numeric one. It
would fail — that path has real bugs, which the header comment already warns about. Untouched here.

### What it costs

You asked about this on #579 and I gave you a bytes figure, which was the wrong unit. Measured
properly this time, both arms in one binary and one compilation so build layout cannot masquerade as
the effect, sampled A/B/B/A so drift cancels:

| | |
|---|---|
| One `LinkIdTransformMap` lookup | **~4.7 ns** |
| `at()` vs `operator[]`, 14 configs × 2 orderings | **−0.17 … +0.34 ns, sign flips** |

The sign instability is the result: the difference is below the noise floor, so the honest figure is
an upper bound of +0.34 ns, not a point estimate. `find()` is indistinguishable too. Worth noting
that link-name length costs only ~0.2 ns, so the `std::string` confirm in `NameId::operator==` is not
the dominant term — the hash-map machinery is.

Counting actual lookups per solve (exact counts, not timing):

| workload | lookups | as % of solve | `at()` upper bound |
|---|---|---|---|
| cart position optimisation | 119 | 0.0004% | 0.0000% |
| numerical IK | 177 | 0.0005% | 0.0000% |
| `CastTest` boxes | 9 576 | 0.046% | 0.003% |
| `CastWorldTest` boxes | 77 604 | 0.34% | 0.024% |
| **`PlanningTest` arm_around_table (22.4 s)** | 127 512 | **0.0027%** | **0.0002%** |
| `ContinuousCollisionGradientTest` | 137 728 | 0.51% | 0.036% |

One correction to those percentages: the sub-second rows are flattered by their denominators, since
~0.09 s of each is process start plus URDF and environment construction. Against compute time the
worst case is roughly 1.6–1.8% for the lookups and **~0.13% for the `at()` bound**. `PlanningTest` is
unaffected at 22.4 s, and it is the realistic row: **two parts per million**.

Tests: `trajopt`, `trajopt_sco`, `trajopt_ifopt`, `trajopt_sqp`, `trajopt_common` green at both
commits; clang-format clean.
