### PR TITLE
Build the docker image in a tmpfs workspace

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,18 +7,17 @@ ENV DEBIAN_FRONTEND noninteractive
 
 USER root
 
+# Use a tmpfs mount for the workspace so as not to unnecessarily copy files into the final image
 # Bind mount the source directory so as not to unnecessarily copy source code into the docker image
-ARG WORKSPACE_DIR=/opt/trajopt
-RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/trajopt \
+ARG WORKSPACE_DIR=/tmpfs/trajopt
+ARG INSTALL_DIR=/opt/trajopt
+RUN mkdir -p ${INSTALL_DIR}
+
+RUN --mount=type=tmpfs,target=${WORKSPACE_DIR} --mount=type=bind,target=${WORKSPACE_DIR}/src/trajopt \
   cd ${WORKSPACE_DIR} \
   && rosdep install \
     --from-paths ${WORKSPACE_DIR}/src \
-    -iry
-
-# Build the repository
-# Bind mount the source directory so as not to unnecessarily copy source code into the docker image
-RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/trajopt \
-  source /opt/tesseract/install/setup.bash \
-  && cd ${WORKSPACE_DIR} \ 
+    -iry \
+  && source /opt/tesseract/install/setup.bash \
   && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
-  && rm -rf build log
+  && cp -r ${WORKSPACE_DIR}/install ${INSTALL_DIR}


### PR DESCRIPTION
Applies the pattern from tesseract-robotics/tesseract#1167 to trajopt: build the workspace on a `tmpfs` mount and copy only the install tree into `/opt/trajopt`. tesseract-robotics/tesseract_ros2#169 did the same for tesseract_ros2, which leaves trajopt as the last repo in the image chain (tesseract → trajopt → tesseract_planning → tesseract_qt → tesseract_ros2) still on the old form.

Worth being clear that this does **not** shrink the image here. Unlike the others, trajopt does no `vcs import`, and the build already ran `rm -rf build log` inside the same `RUN`, so `/opt/trajopt` held nothing but `install/` either way. What it does buy:

* the five Dockerfiles in the chain are finally the same shape
* the build tree lives in RAM rather than the overlay
* two `RUN` layers collapse into one
* `&& cd ${WORKSPACE_DIR} \ ` goes away — the trailing space makes that an escaped space rather than a line continuation, and it only ever worked because Docker strips it

`RUN mkdir -p ${INSTALL_DIR}` before the build is load-bearing: `cp -r .../install ${INSTALL_DIR}` nests correctly only when the destination already exists. tesseract hit exactly that and fixed it in `ff450d3a`.

The install path is unchanged, so `source /opt/trajopt/install/setup.bash` in tesseract_planning's Dockerfile still resolves.
