### PR TITLE
trajopt_sqp/trajopt_ifopt: optional environment-gated trace of the convexified QP and collision rows

### DIFF
--- a/trajopt_ifopt/src/constraints/collision/discrete_collision_constraint.cpp
+++ b/trajopt_ifopt/src/constraints/collision/discrete_collision_constraint.cpp
@@ -256,8 +256,8 @@ int DiscreteCollisionConstraintD::update()
         return (v != nullptr) ? std::atoi(v) : 400;
       }();
       static std::atomic<int> event_counter{ 0 };
-      static std::FILE* const trace_file = std::fopen(
-          (std::string(trace_dir) + "/collision_rows_" + std::to_string(::getpid()) + ".txt").c_str(), "a");
+      static std::FILE* const trace_file =
+          std::fopen((std::string(trace_dir) + "/collision_rows_" + std::to_string(::getpid()) + ".txt").c_str(), "a");
       const int event = event_counter.fetch_add(1);
       if (trace_file != nullptr && event <= max_events)
       {
@@ -298,8 +298,8 @@ int DiscreteCollisionConstraintD::update()
         return (v != nullptr) ? std::atoi(v) : 400;
       }();
       static std::atomic<int> event_counter{ 0 };
-      static std::FILE* const trace_file = std::fopen(
-          (std::string(trace_dir) + "/collision_rows_" + std::to_string(::getpid()) + ".txt").c_str(), "a");
+      static std::FILE* const trace_file =
+          std::fopen((std::string(trace_dir) + "/collision_rows_" + std::to_string(::getpid()) + ".txt").c_str(), "a");
       const int event = event_counter.fetch_add(1);
       if (trace_file != nullptr && event <= max_events)
       {

--- a/trajopt_ifopt/src/constraints/collision/discrete_collision_constraint.cpp
+++ b/trajopt_ifopt/src/constraints/collision/discrete_collision_constraint.cpp
@@ -39,6 +39,20 @@ TRAJOPT_IGNORE_WARNINGS_POP
 #include <trajopt_ifopt/variable_sets/var.h>
 
 #include <trajopt_ifopt/utils/numeric_differentiation.h>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unistd.h>
 
 namespace trajopt_ifopt
 {
@@ -225,6 +239,90 @@ int DiscreteCollisionConstraintD::update()
   }
 
   assert(rows_ == i);
+
+  // Optional trace of the constraint rows (content AND order) built by this update, appended to
+  // <TRAJOPT_TRACE_DIR>/collision_rows_<pid>.txt for the first TRAJOPT_TRACE_MAX_ROW_EVENTS updates
+  // (default 400). Disabled when TRAJOPT_TRACE_DIR is unset; the gate is evaluated once per
+  // process, so the disabled cost is one static-bool check. Read-only: no behaviour change.
+  {
+    static const char* const trace_dir = [] {
+      const char* v = std::getenv("TRAJOPT_TRACE_DIR");
+      return (v != nullptr && v[0] != '\0') ? v : nullptr;
+    }();
+    if (trace_dir != nullptr)
+    {
+      static const int max_events = [] {
+        const char* v = std::getenv("TRAJOPT_TRACE_MAX_ROW_EVENTS");
+        return (v != nullptr) ? std::atoi(v) : 400;
+      }();
+      static std::atomic<int> event_counter{ 0 };
+      static std::FILE* const trace_file = std::fopen(
+          (std::string(trace_dir) + "/collision_rows_" + std::to_string(::getpid()) + ".txt").c_str(), "a");
+      const int event = event_counter.fetch_add(1);
+      if (trace_file != nullptr && event <= max_events)
+      {
+        if (event < max_events)
+        {
+          // One string per event so concurrent updates cannot interleave lines.
+          std::ostringstream ss;
+          ss << "U " << event << " obj=" << static_cast<const void*>(this) << " n=" << rows_ << "\n";
+          ss << std::fixed << std::setprecision(6);
+          // Same container, same traversal as the row-building loop above => identical row order.
+          for (const auto& pair : collision_data_->contact_results_map)
+            for (const auto& contact_results : pair.second)
+              ss << "  " << pair.first.first << "|" << pair.first.second << " d=" << contact_results.distance << "\n";
+          std::fputs(ss.str().c_str(), trace_file);
+        }
+        else
+        {
+          std::fputs("TRUNCATED\n", trace_file);
+        }
+        std::fflush(trace_file);
+      }
+    }
+  }
+
+  // Optional trace of the constraint rows (content AND order) built by this update, appended to
+  // <TRAJOPT_TRACE_DIR>/collision_rows_<pid>.txt for the first TRAJOPT_TRACE_MAX_ROW_EVENTS updates
+  // (default 400). Disabled when TRAJOPT_TRACE_DIR is unset; the gate is evaluated once per
+  // process, so the disabled cost is one static-bool check. Read-only: no behaviour change.
+  {
+    static const char* const trace_dir = [] {
+      const char* v = std::getenv("TRAJOPT_TRACE_DIR");
+      return (v != nullptr && v[0] != '\0') ? v : nullptr;
+    }();
+    if (trace_dir != nullptr)
+    {
+      static const int max_events = [] {
+        const char* v = std::getenv("TRAJOPT_TRACE_MAX_ROW_EVENTS");
+        return (v != nullptr) ? std::atoi(v) : 400;
+      }();
+      static std::atomic<int> event_counter{ 0 };
+      static std::FILE* const trace_file = std::fopen(
+          (std::string(trace_dir) + "/collision_rows_" + std::to_string(::getpid()) + ".txt").c_str(), "a");
+      const int event = event_counter.fetch_add(1);
+      if (trace_file != nullptr && event <= max_events)
+      {
+        if (event < max_events)
+        {
+          // One string per event so concurrent updates cannot interleave lines.
+          std::ostringstream ss;
+          ss << "U " << event << " obj=" << static_cast<const void*>(this) << " n=" << rows_ << "\n";
+          ss << std::fixed << std::setprecision(6);
+          // Same container, same traversal as the row-building loop above => identical row order.
+          for (const auto& pair : collision_data_->contact_results_map)
+            for (const auto& contact_results : pair.second)
+              ss << "  " << pair.first.first << "|" << pair.first.second << " d=" << contact_results.distance << "\n";
+          std::fputs(ss.str().c_str(), trace_file);
+        }
+        else
+        {
+          std::fputs("TRUNCATED\n", trace_file);
+        }
+        std::fflush(trace_file);
+      }
+    }
+  }
 
   return rows_;
 }

--- a/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
@@ -145,24 +145,41 @@ bool OSQPEigenSolver::solve()
           a_i = qp_trace::fnv1a64(d->A->i, sizeof(OSQPInt) * static_cast<std::size_t>(a_nnz));
           a_p = qp_trace::fnv1a64(d->A->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->A->n + 1));
         }
-        std::fprintf(f, "QPSOLVE#%d dims n=%lld m=%lld P_nnz=%lld A_nnz=%lld\n", qp_trace_idx,
-                     static_cast<long long>(num_vars_), static_cast<long long>(num_cnts_), p_nnz, a_nnz);
-        std::fprintf(f, "QPSOLVE#%d P src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
-                     static_cast<unsigned long long>(p_x), static_cast<unsigned long long>(p_i),
+        std::fprintf(f,
+                     "QPSOLVE#%d dims n=%lld m=%lld P_nnz=%lld A_nnz=%lld\n",
+                     qp_trace_idx,
+                     static_cast<long long>(num_vars_),
+                     static_cast<long long>(num_cnts_),
+                     p_nnz,
+                     a_nnz);
+        std::fprintf(f,
+                     "QPSOLVE#%d P src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n",
+                     qp_trace_idx,
+                     static_cast<unsigned long long>(p_x),
+                     static_cast<unsigned long long>(p_i),
                      static_cast<unsigned long long>(p_p));
-        std::fprintf(f, "QPSOLVE#%d A src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
-                     static_cast<unsigned long long>(a_x), static_cast<unsigned long long>(a_i),
+        std::fprintf(f,
+                     "QPSOLVE#%d A src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n",
+                     qp_trace_idx,
+                     static_cast<unsigned long long>(a_x),
+                     static_cast<unsigned long long>(a_i),
                      static_cast<unsigned long long>(a_p));
         // q/l/u: raw double bytes of this wrapper's own members (always current).
-        std::fprintf(f, "QPSOLVE#%d q src=member hash=%016llx n=%lld\n", qp_trace_idx,
+        std::fprintf(f,
+                     "QPSOLVE#%d q src=member hash=%016llx n=%lld\n",
+                     qp_trace_idx,
                      static_cast<unsigned long long>(qp_trace::fnv1a64(
                          gradient_.data(), sizeof(double) * static_cast<std::size_t>(gradient_.size()))),
                      static_cast<long long>(gradient_.size()));
-        std::fprintf(f, "QPSOLVE#%d l src=member hash=%016llx m=%lld\n", qp_trace_idx,
+        std::fprintf(f,
+                     "QPSOLVE#%d l src=member hash=%016llx m=%lld\n",
+                     qp_trace_idx,
                      static_cast<unsigned long long>(qp_trace::fnv1a64(
                          bounds_lower_.data(), sizeof(double) * static_cast<std::size_t>(bounds_lower_.size()))),
                      static_cast<long long>(bounds_lower_.size()));
-        std::fprintf(f, "QPSOLVE#%d u src=member hash=%016llx m=%lld\n", qp_trace_idx,
+        std::fprintf(f,
+                     "QPSOLVE#%d u src=member hash=%016llx m=%lld\n",
+                     qp_trace_idx,
                      static_cast<unsigned long long>(qp_trace::fnv1a64(
                          bounds_upper_.data(), sizeof(double) * static_cast<std::size_t>(bounds_upper_.size()))),
                      static_cast<long long>(bounds_upper_.size()));
@@ -172,13 +189,21 @@ bool OSQPEigenSolver::solve()
                        "adaptive_rho_interval=%lld adaptive_rho_fraction=%.17g adaptive_rho_tolerance=%.17g "
                        "scaling=%lld polishing=%lld max_iter=%lld eps_abs=%.17g eps_rel=%.17g "
                        "check_termination=%lld time_limit=%.17g\n",
-                       qp_trace_idx, static_cast<double>(s->rho), static_cast<long long>(s->rho_is_vec),
-                       static_cast<double>(s->sigma), static_cast<double>(s->alpha),
-                       static_cast<long long>(s->adaptive_rho), static_cast<long long>(s->adaptive_rho_interval),
-                       static_cast<double>(s->adaptive_rho_fraction), static_cast<double>(s->adaptive_rho_tolerance),
-                       static_cast<long long>(s->scaling), static_cast<long long>(s->polishing),
-                       static_cast<long long>(s->max_iter), static_cast<double>(s->eps_abs),
-                       static_cast<double>(s->eps_rel), static_cast<long long>(s->check_termination),
+                       qp_trace_idx,
+                       static_cast<double>(s->rho),
+                       static_cast<long long>(s->rho_is_vec),
+                       static_cast<double>(s->sigma),
+                       static_cast<double>(s->alpha),
+                       static_cast<long long>(s->adaptive_rho),
+                       static_cast<long long>(s->adaptive_rho_interval),
+                       static_cast<double>(s->adaptive_rho_fraction),
+                       static_cast<double>(s->adaptive_rho_tolerance),
+                       static_cast<long long>(s->scaling),
+                       static_cast<long long>(s->polishing),
+                       static_cast<long long>(s->max_iter),
+                       static_cast<double>(s->eps_abs),
+                       static_cast<double>(s->eps_rel),
+                       static_cast<long long>(s->check_termination),
                        static_cast<double>(s->time_limit));
         std::fclose(f);
       }
@@ -251,27 +276,40 @@ bool OSQPEigenSolver::solve()
                      "QPSOLVE#%d info status_val=%lld status_polish=%lld iter=%lld rho_updates=%lld "
                      "rho_estimate=%.17g setup_time=%.17g solve_time=%.17g update_time=%.17g polish_time=%.17g "
                      "obj_val=%.17g prim_res=%.17g dual_res=%.17g\n",
-                     qp_trace_idx, static_cast<long long>(info->status_val), static_cast<long long>(info->status_polish),
-                     static_cast<long long>(info->iter), static_cast<long long>(info->rho_updates),
-                     static_cast<double>(info->rho_estimate), static_cast<double>(info->setup_time),
-                     static_cast<double>(info->solve_time), static_cast<double>(info->update_time),
-                     static_cast<double>(info->polish_time), static_cast<double>(info->obj_val),
-                     static_cast<double>(info->prim_res), static_cast<double>(info->dual_res));
+                     qp_trace_idx,
+                     static_cast<long long>(info->status_val),
+                     static_cast<long long>(info->status_polish),
+                     static_cast<long long>(info->iter),
+                     static_cast<long long>(info->rho_updates),
+                     static_cast<double>(info->rho_estimate),
+                     static_cast<double>(info->setup_time),
+                     static_cast<double>(info->solve_time),
+                     static_cast<double>(info->update_time),
+                     static_cast<double>(info->polish_time),
+                     static_cast<double>(info->obj_val),
+                     static_cast<double>(info->prim_res),
+                     static_cast<double>(info->dual_res));
       // Same success condition as the return path below (read-only re-check).
       if ((solveExitFlag == OsqpEigen::ErrorExitFlag::NoError) &&
           ((status == OsqpEigen::Status::Solved) || (status == OsqpEigen::Status::SolvedInaccurate)))
       {
         const Eigen::VectorXd qp_solution = solver_->getSolution();
-        std::fprintf(f, "QPSOLVE#%d x hash=%016llx n=%lld exitflag=%d status=%d\n", qp_trace_idx,
+        std::fprintf(f,
+                     "QPSOLVE#%d x hash=%016llx n=%lld exitflag=%d status=%d\n",
+                     qp_trace_idx,
                      static_cast<unsigned long long>(qp_trace::fnv1a64(
                          qp_solution.data(), sizeof(double) * static_cast<std::size_t>(qp_solution.size()))),
-                     static_cast<long long>(qp_solution.size()), static_cast<int>(solveExitFlag),
+                     static_cast<long long>(qp_solution.size()),
+                     static_cast<int>(solveExitFlag),
                      static_cast<int>(status));
       }
       else
       {
-        std::fprintf(f, "QPSOLVE#%d x NOT-SOLVED exitflag=%d status=%d\n", qp_trace_idx,
-                     static_cast<int>(solveExitFlag), static_cast<int>(status));
+        std::fprintf(f,
+                     "QPSOLVE#%d x NOT-SOLVED exitflag=%d status=%d\n",
+                     qp_trace_idx,
+                     static_cast<int>(solveExitFlag),
+                     static_cast<int>(status));
       }
       std::fclose(f);
     }
@@ -290,27 +328,40 @@ bool OSQPEigenSolver::solve()
                      "QPSOLVE#%d info status_val=%lld status_polish=%lld iter=%lld rho_updates=%lld "
                      "rho_estimate=%.17g setup_time=%.17g solve_time=%.17g update_time=%.17g polish_time=%.17g "
                      "obj_val=%.17g prim_res=%.17g dual_res=%.17g\n",
-                     qp_trace_idx, static_cast<long long>(info->status_val), static_cast<long long>(info->status_polish),
-                     static_cast<long long>(info->iter), static_cast<long long>(info->rho_updates),
-                     static_cast<double>(info->rho_estimate), static_cast<double>(info->setup_time),
-                     static_cast<double>(info->solve_time), static_cast<double>(info->update_time),
-                     static_cast<double>(info->polish_time), static_cast<double>(info->obj_val),
-                     static_cast<double>(info->prim_res), static_cast<double>(info->dual_res));
+                     qp_trace_idx,
+                     static_cast<long long>(info->status_val),
+                     static_cast<long long>(info->status_polish),
+                     static_cast<long long>(info->iter),
+                     static_cast<long long>(info->rho_updates),
+                     static_cast<double>(info->rho_estimate),
+                     static_cast<double>(info->setup_time),
+                     static_cast<double>(info->solve_time),
+                     static_cast<double>(info->update_time),
+                     static_cast<double>(info->polish_time),
+                     static_cast<double>(info->obj_val),
+                     static_cast<double>(info->prim_res),
+                     static_cast<double>(info->dual_res));
       // Same success condition as the return path below (read-only re-check).
       if ((solveExitFlag == OsqpEigen::ErrorExitFlag::NoError) &&
           ((status == OsqpEigen::Status::Solved) || (status == OsqpEigen::Status::SolvedInaccurate)))
       {
         const Eigen::VectorXd qp_solution = solver_->getSolution();
-        std::fprintf(f, "QPSOLVE#%d x hash=%016llx n=%lld exitflag=%d status=%d\n", qp_trace_idx,
+        std::fprintf(f,
+                     "QPSOLVE#%d x hash=%016llx n=%lld exitflag=%d status=%d\n",
+                     qp_trace_idx,
                      static_cast<unsigned long long>(qp_trace::fnv1a64(
                          qp_solution.data(), sizeof(double) * static_cast<std::size_t>(qp_solution.size()))),
-                     static_cast<long long>(qp_solution.size()), static_cast<int>(solveExitFlag),
+                     static_cast<long long>(qp_solution.size()),
+                     static_cast<int>(solveExitFlag),
                      static_cast<int>(status));
       }
       else
       {
-        std::fprintf(f, "QPSOLVE#%d x NOT-SOLVED exitflag=%d status=%d\n", qp_trace_idx,
-                     static_cast<int>(solveExitFlag), static_cast<int>(status));
+        std::fprintf(f,
+                     "QPSOLVE#%d x NOT-SOLVED exitflag=%d status=%d\n",
+                     qp_trace_idx,
+                     static_cast<int>(solveExitFlag),
+                     static_cast<int>(status));
       }
       std::fclose(f);
     }
@@ -324,77 +375,102 @@ bool OSQPEigenSolver::solve()
       std::cout << "OSQP Solution: " << solver_->getSolution().transpose().format(format) << '\n';
     }
 
-  // Optional trace (see qp_trace.h): digests of the OSQP-side problem data and the settings for the
-  // first TRAJOPT_TRACE_MAX_QPS QP solves of the process; the post-solve half below logs the run info
-  // and a digest of the primal solution. Read-only. qp_trace_idx stays -1 when the trace is off.
-  int qp_trace_idx = -1;
-  if (qp_trace::dir() != nullptr)
-  {
-    static std::atomic<int> qp_counter{ 0 };
-    qp_trace_idx = qp_counter.fetch_add(1);
-    if (qp_trace_idx < qp_trace::maxQps())
+    // Optional trace (see qp_trace.h): digests of the OSQP-side problem data and the settings for the
+    // first TRAJOPT_TRACE_MAX_QPS QP solves of the process; the post-solve half below logs the run info
+    // and a digest of the primal solution. Read-only. qp_trace_idx stays -1 when the trace is off.
+    int qp_trace_idx = -1;
+    if (qp_trace::dir() != nullptr)
     {
-      if (std::FILE* f = qp_trace::open("qp_trace"))
+      static std::atomic<int> qp_counter{ 0 };
+      qp_trace_idx = qp_counter.fetch_add(1);
+      if (qp_trace_idx < qp_trace::maxQps())
       {
-        const OsqpEigen::OSQPData* d = solver_->data()->getData();
-        const OSQPSettings* s = solver_->settings()->getSettings();
-        // P and A: raw bytes of the OSQP CSC arrays held in OsqpEigen's Data object (exact for the
-        // first solve; on later solves they can lag behind in-place update* calls into the workspace).
-        long long p_nnz = -1, a_nnz = -1;
-        std::uint64_t p_x = 0, p_i = 0, p_p = 0, a_x = 0, a_i = 0, a_p = 0;
-        if (d != nullptr && d->P != nullptr && d->P->p != nullptr)
+        if (std::FILE* f = qp_trace::open("qp_trace"))
         {
-          p_nnz = static_cast<long long>(d->P->p[d->P->n]);
-          p_x = qp_trace::fnv1a64(d->P->x, sizeof(OSQPFloat) * static_cast<std::size_t>(p_nnz));
-          p_i = qp_trace::fnv1a64(d->P->i, sizeof(OSQPInt) * static_cast<std::size_t>(p_nnz));
-          p_p = qp_trace::fnv1a64(d->P->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->P->n + 1));
-        }
-        if (d != nullptr && d->A != nullptr && d->A->p != nullptr)
-        {
-          a_nnz = static_cast<long long>(d->A->p[d->A->n]);
-          a_x = qp_trace::fnv1a64(d->A->x, sizeof(OSQPFloat) * static_cast<std::size_t>(a_nnz));
-          a_i = qp_trace::fnv1a64(d->A->i, sizeof(OSQPInt) * static_cast<std::size_t>(a_nnz));
-          a_p = qp_trace::fnv1a64(d->A->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->A->n + 1));
-        }
-        std::fprintf(f, "QPSOLVE#%d dims n=%lld m=%lld P_nnz=%lld A_nnz=%lld\n", qp_trace_idx,
-                     static_cast<long long>(num_vars_), static_cast<long long>(num_cnts_), p_nnz, a_nnz);
-        std::fprintf(f, "QPSOLVE#%d P src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
-                     static_cast<unsigned long long>(p_x), static_cast<unsigned long long>(p_i),
-                     static_cast<unsigned long long>(p_p));
-        std::fprintf(f, "QPSOLVE#%d A src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
-                     static_cast<unsigned long long>(a_x), static_cast<unsigned long long>(a_i),
-                     static_cast<unsigned long long>(a_p));
-        // q/l/u: raw double bytes of this wrapper's own members (always current).
-        std::fprintf(f, "QPSOLVE#%d q src=member hash=%016llx n=%lld\n", qp_trace_idx,
-                     static_cast<unsigned long long>(qp_trace::fnv1a64(
-                         gradient_.data(), sizeof(double) * static_cast<std::size_t>(gradient_.size()))),
-                     static_cast<long long>(gradient_.size()));
-        std::fprintf(f, "QPSOLVE#%d l src=member hash=%016llx m=%lld\n", qp_trace_idx,
-                     static_cast<unsigned long long>(qp_trace::fnv1a64(
-                         lower_bounds_.data(), sizeof(double) * static_cast<std::size_t>(lower_bounds_.size()))),
-                     static_cast<long long>(lower_bounds_.size()));
-        std::fprintf(f, "QPSOLVE#%d u src=member hash=%016llx m=%lld\n", qp_trace_idx,
-                     static_cast<unsigned long long>(qp_trace::fnv1a64(
-                         upper_bounds_.data(), sizeof(double) * static_cast<std::size_t>(upper_bounds_.size()))),
-                     static_cast<long long>(upper_bounds_.size()));
-        if (s != nullptr)
+          const OsqpEigen::OSQPData* d = solver_->data()->getData();
+          const OSQPSettings* s = solver_->settings()->getSettings();
+          // P and A: raw bytes of the OSQP CSC arrays held in OsqpEigen's Data object (exact for the
+          // first solve; on later solves they can lag behind in-place update* calls into the workspace).
+          long long p_nnz = -1, a_nnz = -1;
+          std::uint64_t p_x = 0, p_i = 0, p_p = 0, a_x = 0, a_i = 0, a_p = 0;
+          if (d != nullptr && d->P != nullptr && d->P->p != nullptr)
+          {
+            p_nnz = static_cast<long long>(d->P->p[d->P->n]);
+            p_x = qp_trace::fnv1a64(d->P->x, sizeof(OSQPFloat) * static_cast<std::size_t>(p_nnz));
+            p_i = qp_trace::fnv1a64(d->P->i, sizeof(OSQPInt) * static_cast<std::size_t>(p_nnz));
+            p_p = qp_trace::fnv1a64(d->P->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->P->n + 1));
+          }
+          if (d != nullptr && d->A != nullptr && d->A->p != nullptr)
+          {
+            a_nnz = static_cast<long long>(d->A->p[d->A->n]);
+            a_x = qp_trace::fnv1a64(d->A->x, sizeof(OSQPFloat) * static_cast<std::size_t>(a_nnz));
+            a_i = qp_trace::fnv1a64(d->A->i, sizeof(OSQPInt) * static_cast<std::size_t>(a_nnz));
+            a_p = qp_trace::fnv1a64(d->A->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->A->n + 1));
+          }
           std::fprintf(f,
-                       "QPSOLVE#%d settings rho=%.17g rho_is_vec=%lld sigma=%.17g alpha=%.17g adaptive_rho=%lld "
-                       "adaptive_rho_interval=%lld adaptive_rho_fraction=%.17g adaptive_rho_tolerance=%.17g "
-                       "scaling=%lld polishing=%lld max_iter=%lld eps_abs=%.17g eps_rel=%.17g "
-                       "check_termination=%lld time_limit=%.17g\n",
-                       qp_trace_idx, static_cast<double>(s->rho), static_cast<long long>(s->rho_is_vec),
-                       static_cast<double>(s->sigma), static_cast<double>(s->alpha),
-                       static_cast<long long>(s->adaptive_rho), static_cast<long long>(s->adaptive_rho_interval),
-                       static_cast<double>(s->adaptive_rho_fraction), static_cast<double>(s->adaptive_rho_tolerance),
-                       static_cast<long long>(s->scaling), static_cast<long long>(s->polishing),
-                       static_cast<long long>(s->max_iter), static_cast<double>(s->eps_abs),
-                       static_cast<double>(s->eps_rel), static_cast<long long>(s->check_termination),
-                       static_cast<double>(s->time_limit));
-        std::fclose(f);
+                       "QPSOLVE#%d dims n=%lld m=%lld P_nnz=%lld A_nnz=%lld\n",
+                       qp_trace_idx,
+                       static_cast<long long>(num_vars_),
+                       static_cast<long long>(num_cnts_),
+                       p_nnz,
+                       a_nnz);
+          std::fprintf(f,
+                       "QPSOLVE#%d P src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n",
+                       qp_trace_idx,
+                       static_cast<unsigned long long>(p_x),
+                       static_cast<unsigned long long>(p_i),
+                       static_cast<unsigned long long>(p_p));
+          std::fprintf(f,
+                       "QPSOLVE#%d A src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n",
+                       qp_trace_idx,
+                       static_cast<unsigned long long>(a_x),
+                       static_cast<unsigned long long>(a_i),
+                       static_cast<unsigned long long>(a_p));
+          // q/l/u: raw double bytes of this wrapper's own members (always current).
+          std::fprintf(f,
+                       "QPSOLVE#%d q src=member hash=%016llx n=%lld\n",
+                       qp_trace_idx,
+                       static_cast<unsigned long long>(qp_trace::fnv1a64(
+                           gradient_.data(), sizeof(double) * static_cast<std::size_t>(gradient_.size()))),
+                       static_cast<long long>(gradient_.size()));
+          std::fprintf(f,
+                       "QPSOLVE#%d l src=member hash=%016llx m=%lld\n",
+                       qp_trace_idx,
+                       static_cast<unsigned long long>(qp_trace::fnv1a64(
+                           lower_bounds_.data(), sizeof(double) * static_cast<std::size_t>(lower_bounds_.size()))),
+                       static_cast<long long>(lower_bounds_.size()));
+          std::fprintf(f,
+                       "QPSOLVE#%d u src=member hash=%016llx m=%lld\n",
+                       qp_trace_idx,
+                       static_cast<unsigned long long>(qp_trace::fnv1a64(
+                           upper_bounds_.data(), sizeof(double) * static_cast<std::size_t>(upper_bounds_.size()))),
+                       static_cast<long long>(upper_bounds_.size()));
+          if (s != nullptr)
+            std::fprintf(f,
+                         "QPSOLVE#%d settings rho=%.17g rho_is_vec=%lld sigma=%.17g alpha=%.17g adaptive_rho=%lld "
+                         "adaptive_rho_interval=%lld adaptive_rho_fraction=%.17g adaptive_rho_tolerance=%.17g "
+                         "scaling=%lld polishing=%lld max_iter=%lld eps_abs=%.17g eps_rel=%.17g "
+                         "check_termination=%lld time_limit=%.17g\n",
+                         qp_trace_idx,
+                         static_cast<double>(s->rho),
+                         static_cast<long long>(s->rho_is_vec),
+                         static_cast<double>(s->sigma),
+                         static_cast<double>(s->alpha),
+                         static_cast<long long>(s->adaptive_rho),
+                         static_cast<long long>(s->adaptive_rho_interval),
+                         static_cast<double>(s->adaptive_rho_fraction),
+                         static_cast<double>(s->adaptive_rho_tolerance),
+                         static_cast<long long>(s->scaling),
+                         static_cast<long long>(s->polishing),
+                         static_cast<long long>(s->max_iter),
+                         static_cast<double>(s->eps_abs),
+                         static_cast<double>(s->eps_rel),
+                         static_cast<long long>(s->check_termination),
+                         static_cast<double>(s->time_limit));
+          std::fclose(f);
+        }
       }
     }
-  }
     return true;
   }
 

--- a/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/osqp_eigen_solver.cpp
@@ -28,6 +28,10 @@
 TRAJOPT_IGNORE_WARNINGS_PUSH
 #include <OsqpEigen/OsqpEigen.h>
 TRAJOPT_IGNORE_WARNINGS_POP
+#include <atomic>
+#include "qp_trace.h"
+#include <atomic>
+#include "qp_trace.h"
 
 namespace
 {
@@ -109,6 +113,78 @@ bool OSQPEigenSolver::solve()
       solver_->setWarmStart(x0_, y0_);
   }
 
+  // Optional trace (see qp_trace.h): digests of the OSQP-side problem data and the settings for the
+  // first TRAJOPT_TRACE_MAX_QPS QP solves of the process; the post-solve half below logs the run info
+  // and a digest of the primal solution. Read-only. qp_trace_idx stays -1 when the trace is off.
+  int qp_trace_idx = -1;
+  if (qp_trace::dir() != nullptr)
+  {
+    static std::atomic<int> qp_counter{ 0 };
+    qp_trace_idx = qp_counter.fetch_add(1);
+    if (qp_trace_idx < qp_trace::maxQps())
+    {
+      if (std::FILE* f = qp_trace::open("qp_trace"))
+      {
+        const OsqpEigen::OSQPData* d = solver_->data()->getData();
+        const OSQPSettings* s = solver_->settings()->getSettings();
+        // P and A: raw bytes of the OSQP CSC arrays held in OsqpEigen's Data object (exact for the
+        // first solve; on later solves they can lag behind in-place update* calls into the workspace).
+        long long p_nnz = -1, a_nnz = -1;
+        std::uint64_t p_x = 0, p_i = 0, p_p = 0, a_x = 0, a_i = 0, a_p = 0;
+        if (d != nullptr && d->P != nullptr && d->P->p != nullptr)
+        {
+          p_nnz = static_cast<long long>(d->P->p[d->P->n]);
+          p_x = qp_trace::fnv1a64(d->P->x, sizeof(OSQPFloat) * static_cast<std::size_t>(p_nnz));
+          p_i = qp_trace::fnv1a64(d->P->i, sizeof(OSQPInt) * static_cast<std::size_t>(p_nnz));
+          p_p = qp_trace::fnv1a64(d->P->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->P->n + 1));
+        }
+        if (d != nullptr && d->A != nullptr && d->A->p != nullptr)
+        {
+          a_nnz = static_cast<long long>(d->A->p[d->A->n]);
+          a_x = qp_trace::fnv1a64(d->A->x, sizeof(OSQPFloat) * static_cast<std::size_t>(a_nnz));
+          a_i = qp_trace::fnv1a64(d->A->i, sizeof(OSQPInt) * static_cast<std::size_t>(a_nnz));
+          a_p = qp_trace::fnv1a64(d->A->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->A->n + 1));
+        }
+        std::fprintf(f, "QPSOLVE#%d dims n=%lld m=%lld P_nnz=%lld A_nnz=%lld\n", qp_trace_idx,
+                     static_cast<long long>(num_vars_), static_cast<long long>(num_cnts_), p_nnz, a_nnz);
+        std::fprintf(f, "QPSOLVE#%d P src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
+                     static_cast<unsigned long long>(p_x), static_cast<unsigned long long>(p_i),
+                     static_cast<unsigned long long>(p_p));
+        std::fprintf(f, "QPSOLVE#%d A src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
+                     static_cast<unsigned long long>(a_x), static_cast<unsigned long long>(a_i),
+                     static_cast<unsigned long long>(a_p));
+        // q/l/u: raw double bytes of this wrapper's own members (always current).
+        std::fprintf(f, "QPSOLVE#%d q src=member hash=%016llx n=%lld\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         gradient_.data(), sizeof(double) * static_cast<std::size_t>(gradient_.size()))),
+                     static_cast<long long>(gradient_.size()));
+        std::fprintf(f, "QPSOLVE#%d l src=member hash=%016llx m=%lld\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         bounds_lower_.data(), sizeof(double) * static_cast<std::size_t>(bounds_lower_.size()))),
+                     static_cast<long long>(bounds_lower_.size()));
+        std::fprintf(f, "QPSOLVE#%d u src=member hash=%016llx m=%lld\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         bounds_upper_.data(), sizeof(double) * static_cast<std::size_t>(bounds_upper_.size()))),
+                     static_cast<long long>(bounds_upper_.size()));
+        if (s != nullptr)
+          std::fprintf(f,
+                       "QPSOLVE#%d settings rho=%.17g rho_is_vec=%lld sigma=%.17g alpha=%.17g adaptive_rho=%lld "
+                       "adaptive_rho_interval=%lld adaptive_rho_fraction=%.17g adaptive_rho_tolerance=%.17g "
+                       "scaling=%lld polishing=%lld max_iter=%lld eps_abs=%.17g eps_rel=%.17g "
+                       "check_termination=%lld time_limit=%.17g\n",
+                       qp_trace_idx, static_cast<double>(s->rho), static_cast<long long>(s->rho_is_vec),
+                       static_cast<double>(s->sigma), static_cast<double>(s->alpha),
+                       static_cast<long long>(s->adaptive_rho), static_cast<long long>(s->adaptive_rho_interval),
+                       static_cast<double>(s->adaptive_rho_fraction), static_cast<double>(s->adaptive_rho_tolerance),
+                       static_cast<long long>(s->scaling), static_cast<long long>(s->polishing),
+                       static_cast<long long>(s->max_iter), static_cast<double>(s->eps_abs),
+                       static_cast<double>(s->eps_rel), static_cast<long long>(s->check_termination),
+                       static_cast<double>(s->time_limit));
+        std::fclose(f);
+      }
+    }
+  }
+
   const Eigen::IOFormat format(8);
   if (OSQP_COMPARE_DEBUG_MODE)
   {
@@ -162,6 +238,84 @@ bool OSQPEigenSolver::solve()
   if (OSQP_COMPARE_DEBUG_MODE)
     std::cout << "OSQP Status Value: " << static_cast<int>(solver_->getStatus()) << '\n';
 
+  // Post-solve half of the optional trace (same counter as above): run info and a digest of the
+  // primal solution, or the failure status.
+  if (qp_trace_idx >= 0 && qp_trace_idx < qp_trace::maxQps())
+  {
+    if (std::FILE* f = qp_trace::open("qp_trace"))
+    {
+      const OSQPSolver* os = solver_->solver().get();
+      const OSQPInfo* info = (os != nullptr) ? os->info : nullptr;
+      if (info != nullptr)
+        std::fprintf(f,
+                     "QPSOLVE#%d info status_val=%lld status_polish=%lld iter=%lld rho_updates=%lld "
+                     "rho_estimate=%.17g setup_time=%.17g solve_time=%.17g update_time=%.17g polish_time=%.17g "
+                     "obj_val=%.17g prim_res=%.17g dual_res=%.17g\n",
+                     qp_trace_idx, static_cast<long long>(info->status_val), static_cast<long long>(info->status_polish),
+                     static_cast<long long>(info->iter), static_cast<long long>(info->rho_updates),
+                     static_cast<double>(info->rho_estimate), static_cast<double>(info->setup_time),
+                     static_cast<double>(info->solve_time), static_cast<double>(info->update_time),
+                     static_cast<double>(info->polish_time), static_cast<double>(info->obj_val),
+                     static_cast<double>(info->prim_res), static_cast<double>(info->dual_res));
+      // Same success condition as the return path below (read-only re-check).
+      if ((solveExitFlag == OsqpEigen::ErrorExitFlag::NoError) &&
+          ((status == OsqpEigen::Status::Solved) || (status == OsqpEigen::Status::SolvedInaccurate)))
+      {
+        const Eigen::VectorXd qp_solution = solver_->getSolution();
+        std::fprintf(f, "QPSOLVE#%d x hash=%016llx n=%lld exitflag=%d status=%d\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         qp_solution.data(), sizeof(double) * static_cast<std::size_t>(qp_solution.size()))),
+                     static_cast<long long>(qp_solution.size()), static_cast<int>(solveExitFlag),
+                     static_cast<int>(status));
+      }
+      else
+      {
+        std::fprintf(f, "QPSOLVE#%d x NOT-SOLVED exitflag=%d status=%d\n", qp_trace_idx,
+                     static_cast<int>(solveExitFlag), static_cast<int>(status));
+      }
+      std::fclose(f);
+    }
+  }
+
+  // Post-solve half of the optional trace (same counter as above): run info and a digest of the
+  // primal solution, or the failure status.
+  if (qp_trace_idx >= 0 && qp_trace_idx < qp_trace::maxQps())
+  {
+    if (std::FILE* f = qp_trace::open("qp_trace"))
+    {
+      const OSQPSolver* os = solver_->solver().get();
+      const OSQPInfo* info = (os != nullptr) ? os->info : nullptr;
+      if (info != nullptr)
+        std::fprintf(f,
+                     "QPSOLVE#%d info status_val=%lld status_polish=%lld iter=%lld rho_updates=%lld "
+                     "rho_estimate=%.17g setup_time=%.17g solve_time=%.17g update_time=%.17g polish_time=%.17g "
+                     "obj_val=%.17g prim_res=%.17g dual_res=%.17g\n",
+                     qp_trace_idx, static_cast<long long>(info->status_val), static_cast<long long>(info->status_polish),
+                     static_cast<long long>(info->iter), static_cast<long long>(info->rho_updates),
+                     static_cast<double>(info->rho_estimate), static_cast<double>(info->setup_time),
+                     static_cast<double>(info->solve_time), static_cast<double>(info->update_time),
+                     static_cast<double>(info->polish_time), static_cast<double>(info->obj_val),
+                     static_cast<double>(info->prim_res), static_cast<double>(info->dual_res));
+      // Same success condition as the return path below (read-only re-check).
+      if ((solveExitFlag == OsqpEigen::ErrorExitFlag::NoError) &&
+          ((status == OsqpEigen::Status::Solved) || (status == OsqpEigen::Status::SolvedInaccurate)))
+      {
+        const Eigen::VectorXd qp_solution = solver_->getSolution();
+        std::fprintf(f, "QPSOLVE#%d x hash=%016llx n=%lld exitflag=%d status=%d\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         qp_solution.data(), sizeof(double) * static_cast<std::size_t>(qp_solution.size()))),
+                     static_cast<long long>(qp_solution.size()), static_cast<int>(solveExitFlag),
+                     static_cast<int>(status));
+      }
+      else
+      {
+        std::fprintf(f, "QPSOLVE#%d x NOT-SOLVED exitflag=%d status=%d\n", qp_trace_idx,
+                     static_cast<int>(solveExitFlag), static_cast<int>(status));
+      }
+      std::fclose(f);
+    }
+  }
+
   if ((solveExitFlag == OsqpEigen::ErrorExitFlag::NoError) &&
       ((status == OsqpEigen::Status::Solved) || (status == OsqpEigen::Status::SolvedInaccurate)))
   {
@@ -169,6 +323,78 @@ bool OSQPEigenSolver::solve()
     {
       std::cout << "OSQP Solution: " << solver_->getSolution().transpose().format(format) << '\n';
     }
+
+  // Optional trace (see qp_trace.h): digests of the OSQP-side problem data and the settings for the
+  // first TRAJOPT_TRACE_MAX_QPS QP solves of the process; the post-solve half below logs the run info
+  // and a digest of the primal solution. Read-only. qp_trace_idx stays -1 when the trace is off.
+  int qp_trace_idx = -1;
+  if (qp_trace::dir() != nullptr)
+  {
+    static std::atomic<int> qp_counter{ 0 };
+    qp_trace_idx = qp_counter.fetch_add(1);
+    if (qp_trace_idx < qp_trace::maxQps())
+    {
+      if (std::FILE* f = qp_trace::open("qp_trace"))
+      {
+        const OsqpEigen::OSQPData* d = solver_->data()->getData();
+        const OSQPSettings* s = solver_->settings()->getSettings();
+        // P and A: raw bytes of the OSQP CSC arrays held in OsqpEigen's Data object (exact for the
+        // first solve; on later solves they can lag behind in-place update* calls into the workspace).
+        long long p_nnz = -1, a_nnz = -1;
+        std::uint64_t p_x = 0, p_i = 0, p_p = 0, a_x = 0, a_i = 0, a_p = 0;
+        if (d != nullptr && d->P != nullptr && d->P->p != nullptr)
+        {
+          p_nnz = static_cast<long long>(d->P->p[d->P->n]);
+          p_x = qp_trace::fnv1a64(d->P->x, sizeof(OSQPFloat) * static_cast<std::size_t>(p_nnz));
+          p_i = qp_trace::fnv1a64(d->P->i, sizeof(OSQPInt) * static_cast<std::size_t>(p_nnz));
+          p_p = qp_trace::fnv1a64(d->P->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->P->n + 1));
+        }
+        if (d != nullptr && d->A != nullptr && d->A->p != nullptr)
+        {
+          a_nnz = static_cast<long long>(d->A->p[d->A->n]);
+          a_x = qp_trace::fnv1a64(d->A->x, sizeof(OSQPFloat) * static_cast<std::size_t>(a_nnz));
+          a_i = qp_trace::fnv1a64(d->A->i, sizeof(OSQPInt) * static_cast<std::size_t>(a_nnz));
+          a_p = qp_trace::fnv1a64(d->A->p, sizeof(OSQPInt) * static_cast<std::size_t>(d->A->n + 1));
+        }
+        std::fprintf(f, "QPSOLVE#%d dims n=%lld m=%lld P_nnz=%lld A_nnz=%lld\n", qp_trace_idx,
+                     static_cast<long long>(num_vars_), static_cast<long long>(num_cnts_), p_nnz, a_nnz);
+        std::fprintf(f, "QPSOLVE#%d P src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
+                     static_cast<unsigned long long>(p_x), static_cast<unsigned long long>(p_i),
+                     static_cast<unsigned long long>(p_p));
+        std::fprintf(f, "QPSOLVE#%d A src=osqp-data fmt=csc x=%016llx i=%016llx p=%016llx\n", qp_trace_idx,
+                     static_cast<unsigned long long>(a_x), static_cast<unsigned long long>(a_i),
+                     static_cast<unsigned long long>(a_p));
+        // q/l/u: raw double bytes of this wrapper's own members (always current).
+        std::fprintf(f, "QPSOLVE#%d q src=member hash=%016llx n=%lld\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         gradient_.data(), sizeof(double) * static_cast<std::size_t>(gradient_.size()))),
+                     static_cast<long long>(gradient_.size()));
+        std::fprintf(f, "QPSOLVE#%d l src=member hash=%016llx m=%lld\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         lower_bounds_.data(), sizeof(double) * static_cast<std::size_t>(lower_bounds_.size()))),
+                     static_cast<long long>(lower_bounds_.size()));
+        std::fprintf(f, "QPSOLVE#%d u src=member hash=%016llx m=%lld\n", qp_trace_idx,
+                     static_cast<unsigned long long>(qp_trace::fnv1a64(
+                         upper_bounds_.data(), sizeof(double) * static_cast<std::size_t>(upper_bounds_.size()))),
+                     static_cast<long long>(upper_bounds_.size()));
+        if (s != nullptr)
+          std::fprintf(f,
+                       "QPSOLVE#%d settings rho=%.17g rho_is_vec=%lld sigma=%.17g alpha=%.17g adaptive_rho=%lld "
+                       "adaptive_rho_interval=%lld adaptive_rho_fraction=%.17g adaptive_rho_tolerance=%.17g "
+                       "scaling=%lld polishing=%lld max_iter=%lld eps_abs=%.17g eps_rel=%.17g "
+                       "check_termination=%lld time_limit=%.17g\n",
+                       qp_trace_idx, static_cast<double>(s->rho), static_cast<long long>(s->rho_is_vec),
+                       static_cast<double>(s->sigma), static_cast<double>(s->alpha),
+                       static_cast<long long>(s->adaptive_rho), static_cast<long long>(s->adaptive_rho_interval),
+                       static_cast<double>(s->adaptive_rho_fraction), static_cast<double>(s->adaptive_rho_tolerance),
+                       static_cast<long long>(s->scaling), static_cast<long long>(s->polishing),
+                       static_cast<long long>(s->max_iter), static_cast<double>(s->eps_abs),
+                       static_cast<double>(s->eps_rel), static_cast<long long>(s->check_termination),
+                       static_cast<double>(s->time_limit));
+        std::fclose(f);
+      }
+    }
+  }
     return true;
   }
 

--- a/trajopt_optimizers/trajopt_sqp/src/qp_trace.h
+++ b/trajopt_optimizers/trajopt_sqp/src/qp_trace.h
@@ -1,0 +1,115 @@
+/**
+ * @file qp_trace.h
+ * @brief Optional, environment-gated trace of the convexified QP as handed to the QP solver.
+ *
+ * Private to trajopt_sqp's sources (not installed). Everything here is file-local, function-body
+ * only and touches no public header, so enabling or removing it has no ABI effect.
+ *
+ * Gate: the environment variable TRAJOPT_TRACE_DIR names a directory; when it is unset the trace
+ * is disabled and every use collapses to a single static-bool check. When set, the trace appends
+ * to <dir>/qp_trace_<pid>.txt: the NLP term sets (once), digests of the convexified problem
+ * (P, q, A, l, u, box) for the first TRAJOPT_TRACE_MAX_QPS convexify sweeps (default 3), and the
+ * OSQP-side data digests, settings, run info and primal-solution digest for the first
+ * TRAJOPT_TRACE_MAX_QPS QP solves. Digests are FNV-1a over the raw arrays, so two runs can be
+ * compared byte-for-byte without storing the matrices.
+ *
+ * Diagnostic use: proving whether two solves received the same problem (a profile/dictionary
+ * mismatch, a scaling difference, a non-deterministic rho adaptation) without instrumenting the
+ * caller.
+ */
+#ifndef TRAJOPT_SQP_QP_TRACE_H
+#define TRAJOPT_SQP_QP_TRACE_H
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
+#include <Eigen/Sparse>
+
+namespace trajopt_sqp::qp_trace
+{
+/** @brief The trace directory from TRAJOPT_TRACE_DIR, or nullptr when disabled. Evaluated once. */
+inline const char* dir()
+{
+  static const char* const d = [] {
+    const char* v = std::getenv("TRAJOPT_TRACE_DIR");
+    return (v != nullptr && v[0] != '\0') ? v : nullptr;
+  }();
+  return d;
+}
+
+/** @brief Maximum number of QP solves / convexify sweeps traced per process (TRAJOPT_TRACE_MAX_QPS, default 3). */
+inline int maxQps()
+{
+  static const int n = [] {
+    const char* v = std::getenv("TRAJOPT_TRACE_MAX_QPS");
+    return (v != nullptr) ? std::atoi(v) : 3;
+  }();
+  return n;
+}
+
+/** @brief Open (append) <dir>/<stem>_<pid>.txt, or nullptr when the trace is disabled or the file cannot be opened. */
+inline std::FILE* open(const char* stem)
+{
+  const char* d = dir();
+  if (d == nullptr)
+    return nullptr;
+  const std::string path = std::string(d) + "/" + stem + "_" + std::to_string(::getpid()) + ".txt";
+  return std::fopen(path.c_str(), "a");
+}
+
+/** @brief FNV-1a over raw bytes, chainable through @p h. */
+inline std::uint64_t fnv1a64(const void* data, std::size_t nbytes, std::uint64_t h = 0xcbf29ce484222325ULL)
+{
+  const auto* p = static_cast<const unsigned char*>(data);
+  for (std::size_t i = 0; i < nbytes; ++i)
+  {
+    h ^= static_cast<std::uint64_t>(p[i]);
+    h *= 0x100000001b3ULL;
+  }
+  return h;
+}
+
+/**
+ * @brief Digest a row-major sparse matrix.
+ *
+ * Compressed (the normal case after setFromTriplets/makeCompressed): the three CSR arrays are
+ * hashed separately (values, inner indices, outer indices). Uncompressed fallback: one chained
+ * hash over (row, col, value) per nonzero in InnerIterator order, reported as @p h_val with
+ * @p h_inner and @p h_outer zero. @p fmt names which path ran.
+ */
+inline void hashSparse(const Eigen::SparseMatrix<double, Eigen::RowMajor>& m,
+                       const char*& fmt,
+                       std::uint64_t& h_val,
+                       std::uint64_t& h_inner,
+                       std::uint64_t& h_outer)
+{
+  using SpMat = Eigen::SparseMatrix<double, Eigen::RowMajor>;
+  if (m.isCompressed())
+  {
+    fmt = "csr-arrays";
+    h_val = fnv1a64(m.valuePtr(), sizeof(double) * static_cast<std::size_t>(m.nonZeros()));
+    h_inner = fnv1a64(m.innerIndexPtr(), sizeof(SpMat::StorageIndex) * static_cast<std::size_t>(m.nonZeros()));
+    h_outer = fnv1a64(m.outerIndexPtr(), sizeof(SpMat::StorageIndex) * static_cast<std::size_t>(m.outerSize() + 1));
+    return;
+  }
+  fmt = "triplet-iter";
+  std::uint64_t h = 0xcbf29ce484222325ULL;
+  for (Eigen::Index k = 0; k < m.outerSize(); ++k)
+  {
+    for (SpMat::InnerIterator it(m, k); it; ++it)
+    {
+      const std::int64_t rc[2] = { static_cast<std::int64_t>(it.row()), static_cast<std::int64_t>(it.col()) };
+      const double v = it.value();
+      h = fnv1a64(rc, sizeof(rc), h);
+      h = fnv1a64(&v, sizeof(v), h);
+    }
+  }
+  h_val = h;
+  h_inner = 0;
+  h_outer = 0;
+}
+}  // namespace trajopt_sqp::qp_trace
+
+#endif  // TRAJOPT_SQP_QP_TRACE_H

--- a/trajopt_optimizers/trajopt_sqp/src/trajopt_qp_problem.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/trajopt_qp_problem.cpp
@@ -9,6 +9,10 @@
 #include <algorithm>
 #include <utility>
 #include <iostream>
+#include "qp_trace.h"
+#include <atomic>
+#include "qp_trace.h"
+#include <atomic>
 #include <cassert>
 
 /**
@@ -723,6 +727,58 @@ void TrajOptQPProblem::Implementation::convexify()
 
   // Update if dynamic constraints are present
   update();
+
+  // Optional trace (see qp_trace.h): enumerate the NLP term sets exactly once per process, on the
+  // first convexify. kind=cost -> added via addCostSet (bucket=objective: squared, objective-only,
+  // no rows/slacks; bucket=hinge/abs: costified constraints that add QP rows + slack variables).
+  // kind=cnt -> added via addConstraintSet (bucket=merit, adds QP rows + slack variables).
+  if (qp_trace::dir() != nullptr)
+  {
+    static std::atomic<bool> terms_dumped{ false };
+    if (!terms_dumped.exchange(true))
+    {
+      if (std::FILE* f = qp_trace::open("qp_trace"))
+      {
+        const std::size_t n_hinge = hinge_costs.size() + dyn_hinge_costs.size();
+        for (const auto& term : objective_terms)
+          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=objective\n", term->getName().c_str(),
+                       static_cast<long long>(term->getRows()));
+        for (std::size_t i = 0; i < penalty_constraints.size(); ++i)
+          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=%s\n", penalty_constraints[i]->getName().c_str(),
+                       static_cast<long long>(penalty_constraints[i]->getRows()), (i < n_hinge) ? "hinge" : "abs");
+        for (const auto& term : merit_constraints)
+          std::fprintf(f, "TERM kind=cnt name=%s rows=%lld bucket=merit\n", term->getName().c_str(),
+                       static_cast<long long>(term->getRows()));
+        std::fclose(f);
+      }
+    }
+  }
+
+  // Optional trace (see qp_trace.h): enumerate the NLP term sets exactly once per process, on the
+  // first convexify. kind=cost -> added via addCostSet (bucket=objective: squared, objective-only,
+  // no rows/slacks; bucket=hinge/abs: costified constraints that add QP rows + slack variables).
+  // kind=cnt -> added via addConstraintSet (bucket=merit, adds QP rows + slack variables).
+  if (qp_trace::dir() != nullptr)
+  {
+    static std::atomic<bool> terms_dumped{ false };
+    if (!terms_dumped.exchange(true))
+    {
+      if (std::FILE* f = qp_trace::open("qp_trace"))
+      {
+        const std::size_t n_hinge = hinge_costs.size() + dyn_hinge_costs.size();
+        for (const auto& term : objective_terms)
+          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=objective\n", term->getName().c_str(),
+                       static_cast<long long>(term->getRows()));
+        for (std::size_t i = 0; i < penalty_constraints.size(); ++i)
+          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=%s\n", penalty_constraints[i]->getName().c_str(),
+                       static_cast<long long>(penalty_constraints[i]->getRows()), (i < n_hinge) ? "hinge" : "abs");
+        for (const auto& term : merit_constraints)
+          std::fprintf(f, "TERM kind=cnt name=%s rows=%lld bucket=merit\n", term->getName().c_str(),
+                       static_cast<long long>(term->getRows()));
+        std::fclose(f);
+      }
+    }
+  }
 
   // Get current variable values
   const Eigen::VectorXd x_initial = variables->getValues();

--- a/trajopt_optimizers/trajopt_sqp/src/trajopt_qp_problem.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/trajopt_qp_problem.cpp
@@ -741,13 +741,20 @@ void TrajOptQPProblem::Implementation::convexify()
       {
         const std::size_t n_hinge = hinge_costs.size() + dyn_hinge_costs.size();
         for (const auto& term : objective_terms)
-          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=objective\n", term->getName().c_str(),
+          std::fprintf(f,
+                       "TERM kind=cost name=%s rows=%lld bucket=objective\n",
+                       term->getName().c_str(),
                        static_cast<long long>(term->getRows()));
         for (std::size_t i = 0; i < penalty_constraints.size(); ++i)
-          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=%s\n", penalty_constraints[i]->getName().c_str(),
-                       static_cast<long long>(penalty_constraints[i]->getRows()), (i < n_hinge) ? "hinge" : "abs");
+          std::fprintf(f,
+                       "TERM kind=cost name=%s rows=%lld bucket=%s\n",
+                       penalty_constraints[i]->getName().c_str(),
+                       static_cast<long long>(penalty_constraints[i]->getRows()),
+                       (i < n_hinge) ? "hinge" : "abs");
         for (const auto& term : merit_constraints)
-          std::fprintf(f, "TERM kind=cnt name=%s rows=%lld bucket=merit\n", term->getName().c_str(),
+          std::fprintf(f,
+                       "TERM kind=cnt name=%s rows=%lld bucket=merit\n",
+                       term->getName().c_str(),
                        static_cast<long long>(term->getRows()));
         std::fclose(f);
       }
@@ -767,13 +774,20 @@ void TrajOptQPProblem::Implementation::convexify()
       {
         const std::size_t n_hinge = hinge_costs.size() + dyn_hinge_costs.size();
         for (const auto& term : objective_terms)
-          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=objective\n", term->getName().c_str(),
+          std::fprintf(f,
+                       "TERM kind=cost name=%s rows=%lld bucket=objective\n",
+                       term->getName().c_str(),
                        static_cast<long long>(term->getRows()));
         for (std::size_t i = 0; i < penalty_constraints.size(); ++i)
-          std::fprintf(f, "TERM kind=cost name=%s rows=%lld bucket=%s\n", penalty_constraints[i]->getName().c_str(),
-                       static_cast<long long>(penalty_constraints[i]->getRows()), (i < n_hinge) ? "hinge" : "abs");
+          std::fprintf(f,
+                       "TERM kind=cost name=%s rows=%lld bucket=%s\n",
+                       penalty_constraints[i]->getName().c_str(),
+                       static_cast<long long>(penalty_constraints[i]->getRows()),
+                       (i < n_hinge) ? "hinge" : "abs");
         for (const auto& term : merit_constraints)
-          std::fprintf(f, "TERM kind=cnt name=%s rows=%lld bucket=merit\n", term->getName().c_str(),
+          std::fprintf(f,
+                       "TERM kind=cnt name=%s rows=%lld bucket=merit\n",
+                       term->getName().c_str(),
                        static_cast<long long>(term->getRows()));
         std::fclose(f);
       }

--- a/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
@@ -256,29 +256,51 @@ bool TrustRegionSQPSolver::stepSQPSolver()
         std::fprintf(f,
                      "CONVEXIFY#%d dims nv=%lld nc=%lld P_nnz=%lld A_nnz=%lld first_time=%d dims_changed=%d "
                      "penalty_iter=%d convex_iter=%d overall_iter=%d\n",
-                     idx, static_cast<long long>(nv), static_cast<long long>(nc),
-                     static_cast<long long>(P.nonZeros()), static_cast<long long>(A.nonZeros()),
-                     first_time ? 1 : 0, dims_changed ? 1 : 0, results_.penalty_iteration,
-                     results_.convexify_iteration, results_.overall_iteration);
-        std::fprintf(f, "CONVEXIFY#%d P fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, p_fmt,
-                     static_cast<unsigned long long>(p_val), static_cast<unsigned long long>(p_inner),
+                     idx,
+                     static_cast<long long>(nv),
+                     static_cast<long long>(nc),
+                     static_cast<long long>(P.nonZeros()),
+                     static_cast<long long>(A.nonZeros()),
+                     first_time ? 1 : 0,
+                     dims_changed ? 1 : 0,
+                     results_.penalty_iteration,
+                     results_.convexify_iteration,
+                     results_.overall_iteration);
+        std::fprintf(f,
+                     "CONVEXIFY#%d P fmt=%s val=%016llx inner=%016llx outer=%016llx\n",
+                     idx,
+                     p_fmt,
+                     static_cast<unsigned long long>(p_val),
+                     static_cast<unsigned long long>(p_inner),
                      static_cast<unsigned long long>(p_outer));
-        std::fprintf(f, "CONVEXIFY#%d q hash=%016llx n=%lld\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d q hash=%016llx n=%lld\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(q.data(), sizeof(double) * static_cast<std::size_t>(q.size()))),
                      static_cast<long long>(q.size()));
-        std::fprintf(f, "CONVEXIFY#%d A fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, a_fmt,
-                     static_cast<unsigned long long>(a_val), static_cast<unsigned long long>(a_inner),
+        std::fprintf(f,
+                     "CONVEXIFY#%d A fmt=%s val=%016llx inner=%016llx outer=%016llx\n",
+                     idx,
+                     a_fmt,
+                     static_cast<unsigned long long>(a_val),
+                     static_cast<unsigned long long>(a_inner),
                      static_cast<unsigned long long>(a_outer));
-        std::fprintf(f, "CONVEXIFY#%d l hash=%016llx m=%lld\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d l hash=%016llx m=%lld\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(l.data(), sizeof(double) * static_cast<std::size_t>(l.size()))),
                      static_cast<long long>(l.size()));
-        std::fprintf(f, "CONVEXIFY#%d u hash=%016llx m=%lld\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d u hash=%016llx m=%lld\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(u.data(), sizeof(double) * static_cast<std::size_t>(u.size()))),
                      static_cast<long long>(u.size()));
-        std::fprintf(f, "CONVEXIFY#%d box hash=%016llx box[0]=%.17g merit_coeff[0]=%.17g\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d box hash=%016llx box[0]=%.17g merit_coeff[0]=%.17g\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(box.data(), sizeof(double) * static_cast<std::size_t>(box.size()))),
                      box.size() > 0 ? box[0] : -1.0,
@@ -315,29 +337,51 @@ bool TrustRegionSQPSolver::stepSQPSolver()
         std::fprintf(f,
                      "CONVEXIFY#%d dims nv=%lld nc=%lld P_nnz=%lld A_nnz=%lld first_time=%d dims_changed=%d "
                      "penalty_iter=%d convex_iter=%d overall_iter=%d\n",
-                     idx, static_cast<long long>(nv), static_cast<long long>(nc),
-                     static_cast<long long>(P.nonZeros()), static_cast<long long>(A.nonZeros()),
-                     first_time ? 1 : 0, dims_changed ? 1 : 0, results_.penalty_iteration,
-                     results_.convexify_iteration, results_.overall_iteration);
-        std::fprintf(f, "CONVEXIFY#%d P fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, p_fmt,
-                     static_cast<unsigned long long>(p_val), static_cast<unsigned long long>(p_inner),
+                     idx,
+                     static_cast<long long>(nv),
+                     static_cast<long long>(nc),
+                     static_cast<long long>(P.nonZeros()),
+                     static_cast<long long>(A.nonZeros()),
+                     first_time ? 1 : 0,
+                     dims_changed ? 1 : 0,
+                     results_.penalty_iteration,
+                     results_.convexify_iteration,
+                     results_.overall_iteration);
+        std::fprintf(f,
+                     "CONVEXIFY#%d P fmt=%s val=%016llx inner=%016llx outer=%016llx\n",
+                     idx,
+                     p_fmt,
+                     static_cast<unsigned long long>(p_val),
+                     static_cast<unsigned long long>(p_inner),
                      static_cast<unsigned long long>(p_outer));
-        std::fprintf(f, "CONVEXIFY#%d q hash=%016llx n=%lld\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d q hash=%016llx n=%lld\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(q.data(), sizeof(double) * static_cast<std::size_t>(q.size()))),
                      static_cast<long long>(q.size()));
-        std::fprintf(f, "CONVEXIFY#%d A fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, a_fmt,
-                     static_cast<unsigned long long>(a_val), static_cast<unsigned long long>(a_inner),
+        std::fprintf(f,
+                     "CONVEXIFY#%d A fmt=%s val=%016llx inner=%016llx outer=%016llx\n",
+                     idx,
+                     a_fmt,
+                     static_cast<unsigned long long>(a_val),
+                     static_cast<unsigned long long>(a_inner),
                      static_cast<unsigned long long>(a_outer));
-        std::fprintf(f, "CONVEXIFY#%d l hash=%016llx m=%lld\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d l hash=%016llx m=%lld\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(l.data(), sizeof(double) * static_cast<std::size_t>(l.size()))),
                      static_cast<long long>(l.size()));
-        std::fprintf(f, "CONVEXIFY#%d u hash=%016llx m=%lld\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d u hash=%016llx m=%lld\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(u.data(), sizeof(double) * static_cast<std::size_t>(u.size()))),
                      static_cast<long long>(u.size()));
-        std::fprintf(f, "CONVEXIFY#%d box hash=%016llx box[0]=%.17g merit_coeff[0]=%.17g\n", idx,
+        std::fprintf(f,
+                     "CONVEXIFY#%d box hash=%016llx box[0]=%.17g merit_coeff[0]=%.17g\n",
+                     idx,
                      static_cast<unsigned long long>(
                          qp_trace::fnv1a64(box.data(), sizeof(double) * static_cast<std::size_t>(box.size()))),
                      box.size() > 0 ? box[0] : -1.0,

--- a/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
+++ b/trajopt_optimizers/trajopt_sqp/src/trust_region_sqp_solver.cpp
@@ -34,6 +34,10 @@
 
 #include <console_bridge/console.h>
 #include <chrono>
+#include <atomic>
+#include "qp_trace.h"
+#include <atomic>
+#include "qp_trace.h"
 #include <cassert>
 
 namespace trajopt_sqp
@@ -223,6 +227,124 @@ bool TrustRegionSQPSolver::stepSQPSolver()
     qp_solver->updateLinearConstraintsMatrix(qp_problem->getConstraintMatrix());
     qp_solver->updateBounds(qp_problem->getBoundsLower(), qp_problem->getBoundsUpper());
     qp_solver->setWarmStart(*qp_problem);
+  }
+
+  // Optional trace (see qp_trace.h): digests of the convexified QP exactly as handed to the QP
+  // solver, for the first TRAJOPT_TRACE_MAX_QPS convexify sweeps of the process. Read-only.
+  if (qp_trace::dir() != nullptr)
+  {
+    static std::atomic<int> convexify_counter{ 0 };
+    const int idx = convexify_counter.fetch_add(1);
+    if (idx < qp_trace::maxQps())
+    {
+      if (std::FILE* f = qp_trace::open("qp_trace"))
+      {
+        const trajopt_ifopt::Jacobian& P = qp_problem->getHessian();
+        const Eigen::VectorXd& q = qp_problem->getGradient();
+        const trajopt_ifopt::Jacobian& A = qp_problem->getConstraintMatrix();
+        const Eigen::VectorXd& l = qp_problem->getBoundsLower();
+        const Eigen::VectorXd& u = qp_problem->getBoundsUpper();
+        const Eigen::VectorXd& box = qp_problem->getBoxSize();
+
+        const char* p_fmt = nullptr;
+        std::uint64_t p_val = 0, p_inner = 0, p_outer = 0;
+        qp_trace::hashSparse(P, p_fmt, p_val, p_inner, p_outer);
+        const char* a_fmt = nullptr;
+        std::uint64_t a_val = 0, a_inner = 0, a_outer = 0;
+        qp_trace::hashSparse(A, a_fmt, a_val, a_inner, a_outer);
+
+        std::fprintf(f,
+                     "CONVEXIFY#%d dims nv=%lld nc=%lld P_nnz=%lld A_nnz=%lld first_time=%d dims_changed=%d "
+                     "penalty_iter=%d convex_iter=%d overall_iter=%d\n",
+                     idx, static_cast<long long>(nv), static_cast<long long>(nc),
+                     static_cast<long long>(P.nonZeros()), static_cast<long long>(A.nonZeros()),
+                     first_time ? 1 : 0, dims_changed ? 1 : 0, results_.penalty_iteration,
+                     results_.convexify_iteration, results_.overall_iteration);
+        std::fprintf(f, "CONVEXIFY#%d P fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, p_fmt,
+                     static_cast<unsigned long long>(p_val), static_cast<unsigned long long>(p_inner),
+                     static_cast<unsigned long long>(p_outer));
+        std::fprintf(f, "CONVEXIFY#%d q hash=%016llx n=%lld\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(q.data(), sizeof(double) * static_cast<std::size_t>(q.size()))),
+                     static_cast<long long>(q.size()));
+        std::fprintf(f, "CONVEXIFY#%d A fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, a_fmt,
+                     static_cast<unsigned long long>(a_val), static_cast<unsigned long long>(a_inner),
+                     static_cast<unsigned long long>(a_outer));
+        std::fprintf(f, "CONVEXIFY#%d l hash=%016llx m=%lld\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(l.data(), sizeof(double) * static_cast<std::size_t>(l.size()))),
+                     static_cast<long long>(l.size()));
+        std::fprintf(f, "CONVEXIFY#%d u hash=%016llx m=%lld\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(u.data(), sizeof(double) * static_cast<std::size_t>(u.size()))),
+                     static_cast<long long>(u.size()));
+        std::fprintf(f, "CONVEXIFY#%d box hash=%016llx box[0]=%.17g merit_coeff[0]=%.17g\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(box.data(), sizeof(double) * static_cast<std::size_t>(box.size()))),
+                     box.size() > 0 ? box[0] : -1.0,
+                     results_.merit_error_coeffs.size() > 0 ? results_.merit_error_coeffs[0] : -1.0);
+        std::fclose(f);
+      }
+    }
+  }
+
+  // Optional trace (see qp_trace.h): digests of the convexified QP exactly as handed to the QP
+  // solver, for the first TRAJOPT_TRACE_MAX_QPS convexify sweeps of the process. Read-only.
+  if (qp_trace::dir() != nullptr)
+  {
+    static std::atomic<int> convexify_counter{ 0 };
+    const int idx = convexify_counter.fetch_add(1);
+    if (idx < qp_trace::maxQps())
+    {
+      if (std::FILE* f = qp_trace::open("qp_trace"))
+      {
+        const trajopt_ifopt::Jacobian& P = qp_problem->getHessian();
+        const Eigen::VectorXd& q = qp_problem->getGradient();
+        const trajopt_ifopt::Jacobian& A = qp_problem->getConstraintMatrix();
+        const Eigen::VectorXd& l = qp_problem->getBoundsLower();
+        const Eigen::VectorXd& u = qp_problem->getBoundsUpper();
+        const Eigen::VectorXd& box = qp_problem->getBoxSize();
+
+        const char* p_fmt = nullptr;
+        std::uint64_t p_val = 0, p_inner = 0, p_outer = 0;
+        qp_trace::hashSparse(P, p_fmt, p_val, p_inner, p_outer);
+        const char* a_fmt = nullptr;
+        std::uint64_t a_val = 0, a_inner = 0, a_outer = 0;
+        qp_trace::hashSparse(A, a_fmt, a_val, a_inner, a_outer);
+
+        std::fprintf(f,
+                     "CONVEXIFY#%d dims nv=%lld nc=%lld P_nnz=%lld A_nnz=%lld first_time=%d dims_changed=%d "
+                     "penalty_iter=%d convex_iter=%d overall_iter=%d\n",
+                     idx, static_cast<long long>(nv), static_cast<long long>(nc),
+                     static_cast<long long>(P.nonZeros()), static_cast<long long>(A.nonZeros()),
+                     first_time ? 1 : 0, dims_changed ? 1 : 0, results_.penalty_iteration,
+                     results_.convexify_iteration, results_.overall_iteration);
+        std::fprintf(f, "CONVEXIFY#%d P fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, p_fmt,
+                     static_cast<unsigned long long>(p_val), static_cast<unsigned long long>(p_inner),
+                     static_cast<unsigned long long>(p_outer));
+        std::fprintf(f, "CONVEXIFY#%d q hash=%016llx n=%lld\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(q.data(), sizeof(double) * static_cast<std::size_t>(q.size()))),
+                     static_cast<long long>(q.size()));
+        std::fprintf(f, "CONVEXIFY#%d A fmt=%s val=%016llx inner=%016llx outer=%016llx\n", idx, a_fmt,
+                     static_cast<unsigned long long>(a_val), static_cast<unsigned long long>(a_inner),
+                     static_cast<unsigned long long>(a_outer));
+        std::fprintf(f, "CONVEXIFY#%d l hash=%016llx m=%lld\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(l.data(), sizeof(double) * static_cast<std::size_t>(l.size()))),
+                     static_cast<long long>(l.size()));
+        std::fprintf(f, "CONVEXIFY#%d u hash=%016llx m=%lld\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(u.data(), sizeof(double) * static_cast<std::size_t>(u.size()))),
+                     static_cast<long long>(u.size()));
+        std::fprintf(f, "CONVEXIFY#%d box hash=%016llx box[0]=%.17g merit_coeff[0]=%.17g\n", idx,
+                     static_cast<unsigned long long>(
+                         qp_trace::fnv1a64(box.data(), sizeof(double) * static_cast<std::size_t>(box.size()))),
+                     box.size() > 0 ? box[0] : -1.0,
+                     results_.merit_error_coeffs.size() > 0 ? results_.merit_error_coeffs[0] : -1.0);
+        std::fclose(f);
+      }
+    }
   }
   else
   {


### PR DESCRIPTION
Adds an opt-in diagnostic trace, disabled unless TRAJOPT_TRACE_DIR names a directory (the gate is
evaluated once per process, so the disabled cost is a single static-bool check per site):

  <dir>/qp_trace_<pid>.txt
    - the NLP term sets, once, on the first convexify (kind, name, rows, bucket)
    - digests of the convexified problem (P, q, A, l, u, box) exactly as handed to the QP solver,
      for the first TRAJOPT_TRACE_MAX_QPS convexify sweeps (default 3)
    - the OSQP-side data digests, settings, run info and a digest of the primal solution for the
      first TRAJOPT_TRACE_MAX_QPS QP solves
  <dir>/collision_rows_<pid>.txt
    - the discrete collision constraint rows (content and order) per update, for the first
      TRAJOPT_TRACE_MAX_ROW_EVENTS updates (default 400)

Digests are FNV-1a over the raw arrays, so two runs can be compared byte-for-byte without storing
matrices. Typical use: proving whether two solves received the same problem (a profile mismatch,
a scaling difference, a non-deterministic rho adaptation) without instrumenting the caller.

All code is function-body only with file-local helpers in a private header (trajopt_sqp/src/qp_trace.h,
not installed); no public header or class changes; read-only with respect to the solve.